### PR TITLE
Allow autoplace channels to work in survival mode

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.0.10:dev")
-    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.3.25-GTNH:dev")
+    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.3.46-GTNH:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -2591,7 +2591,7 @@ public class StructureUtility {
                     // we will bypass the chatter filter here, as this is a warning that player definitively want to see
                     // instead of some false positive error messages like item not find
                     warnNoExplicitSubChannel(env.getActor());
-                return backing.survivalPlaceBlock(t, world, x, y, z, trigger, env);
+                return backing.survivalPlaceBlock(t, world, x, y, z, newTrigger, env);
             }
         };
     }


### PR DESCRIPTION
Modifies `PlaceResult` to return updated `newTrigger`.

Tested and allows the use of channels to auto place multiblocks in survival.

![Capture](https://user-images.githubusercontent.com/109012629/236081477-2b4db9bc-4c55-45ab-8189-fe6355194064.PNG)
![Capture](https://user-images.githubusercontent.com/109012629/236081642-144530f6-b548-451b-b3ae-5d0322f76039.PNG)

The hologram projector attempts to place the correct tier of glass.


Please let me know if I'm missing something.