### PR TITLE
Fix IStructureElementChain returning an invalid Iterable

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.4.2:dev")
-    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.19-GTNH:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.5.19:dev")
+    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.44-GTNH:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,10 +50,10 @@ enableGenericInjection = true
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = com.gtnewhorizon.structurelib.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = StructureLib.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.26'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
 }
 
 

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLib.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLib.java
@@ -42,7 +42,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 @Mod(
         modid = StructureLibAPI.MOD_ID,
         name = "StructureLib",
-        version = "GRADLETOKEN_VERSION",
+        version = Tags.VERSION,
         acceptableRemoteVersions = "*",
         guiFactory = "com.gtnewhorizon.structurelib.GuiFactory")
 public class StructureLib {

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
@@ -62,7 +62,8 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
             if (e == null) continue;
             if (predicate == null) predicate = e.getPredicate();
             else predicate = predicate.or(e.getPredicate());
-            is.add(e.getStacks());
+            Iterable<ItemStack> stacks = e.getStacks();
+            if (stacks != null) is.add(stacks);
         }
         if (predicate == null) return null;
         return new BlocksToPlace(predicate, Iterables.concat(is));


### PR DESCRIPTION
You shouldn't concat null iterables as that will just cause the following whenever you try to iterate over it.

```
[STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:787]: java.lang.NullPointerException: Cannot invoke "java.lang.Iterable.iterator()" because "from" is null
[STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at System//com.google.common.collect.Iterables$3.transform(Iterables.java:512)
[STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at System//com.google.common.collect.Iterables$3.transform(Iterables.java:509)
[STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at System//com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48)
[STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at System//com.google.common.collect.Iterators$5.hasNext(Iterators.java:543)
```