### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -1,3 +1,4 @@
+tile.structurelib.blockhint.name=Hint
 tile.structurelib.blockhint.0.name=Hint 1 dot
 tile.structurelib.blockhint.1.name=Hint 2 dots
 tile.structurelib.blockhint.2.name=Hint 3 dots

--- a/src/main/resources/assets/structurelib/lang/zh_CN.lang
+++ b/src/main/resources/assets/structurelib/lang/zh_CN.lang
@@ -1,3 +1,4 @@
+tile.structurelib.blockhint.name=提示方块
 tile.structurelib.blockhint.0.name=提示方块：1号
 tile.structurelib.blockhint.1.name=提示方块：2号
 tile.structurelib.blockhint.2.name=提示方块：3号


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.