### PR TITLE
Fix channel values in tooltip.

### DIFF
--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
@@ -378,11 +378,12 @@ public class StructureLibAPI {
     public static void registerChannelItem(final String channel, final String modid, final int channelValue,
             final ItemStack stack) {
         ChannelDescription.item(channel, channelValue, stack);
+        // Value 0 is for "Not set", usable values are shifted by 1.
         AnimatedTooltipHandler.addItemTooltip(
                 stack,
-                AnimatedTooltipHandler.translatedText("structurelib.tooltip.channelvalue", channelValue, channel));
+                AnimatedTooltipHandler.translatedText("structurelib.tooltip.channelvalue", channelValue - 1, channel));
         AnimatedTooltipHandler.addItemTooltip(
                 stack,
-                AnimatedTooltipHandler.translatedText("structurelib.tooltip.indicator_dnd", channelValue, channel));
+                AnimatedTooltipHandler.translatedText("structurelib.tooltip.indicator_dnd", channelValue - 1, channel));
     }
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20128.

Value in the tooltip needs to be shifted by one, since a value of 0 indicates "Not set".

Tested:

![](https://i.imgur.com/2p0I8WX.png)

Copying the setting into a hologram and autoplacing builds a structure with the correct glass.