### PR TITLE
Fix Hologram Projector Shift-Use opening both GUIs

### DIFF
--- a/src/main/java/com/gtnewhorizon/structurelib/item/ItemConstructableTrigger.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/item/ItemConstructableTrigger.java
@@ -29,9 +29,10 @@ public class ItemConstructableTrigger extends Item {
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
         if (getMovingObjectPositionFromPlayer(world, player, true) == null) {
-            if (!world.isRemote) {
+            // channel gui is opened from server and config gui from client
+            if (!world.isRemote && !player.isSneaking()) {
                 player.openGui(StructureLib.instance(), 0, world, player.inventory.currentItem, 0, 0);
-            } else if (player.isSneaking()) {
+            } else if (world.isRemote && player.isSneaking()) {
                 StructureLib.instance().proxy().displayConfigGUI("registries");
             }
         }


### PR DESCRIPTION
I'm sorry, #45 had a logic derp that caused Shift-Rclick to try to open both GUIs of the Hologram Projector. I missed it, because I was testing with dedicated server.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21262#issuecomment-3289518456