### PR TITLE
Small improvements to the channel config GUI

### DIFF
--- a/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java
@@ -174,7 +174,7 @@ public class GuiScreenConfigureChannels extends GuiContainer implements IGuiScre
                 .stream(
                         Splitter.on("\\n").split(StatCollector.translateToLocal(I18N_PREFIX + "info")).spliterator(),
                         false)
-                .flatMap(line -> fontRendererObj.listFormattedStringToWidth(line, width * 3 / 5).stream())
+                .flatMap(line -> fontRendererObj.listFormattedStringToWidth(line, width * 1 / 3).stream())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java
@@ -164,38 +164,15 @@ public class GuiScreenConfigureChannels extends GuiContainer implements IGuiScre
         list.onGuiInit(this);
         autoCompleteList.onGuiInit(this);
 
-        addButton(
-                new GuiButton(
-                        ADD_BTN,
-                        guiLeft + 12,
-                        guiTop + 157,
-                        47,
-                        20,
-                        I18n.format("item.structurelib.constructableTrigger.gui.add")));
-        addButton(
-                new GuiButton(
-                        UNSET_BTN,
-                        guiLeft + 65,
-                        guiTop + 157,
-                        47,
-                        20,
-                        I18n.format("item.structurelib.constructableTrigger.gui.unset")));
-        addButton(
-                new GuiButton(
-                        WIPE_BTN,
-                        guiLeft + 118,
-                        guiTop + 157,
-                        47,
-                        20,
-                        I18n.format("item.structurelib.constructableTrigger.gui.wipe")));
+        addButton(new GuiButton(ADD_BTN, guiLeft + 12, guiTop + 157, 47, 20, I18n.format(I18N_PREFIX + "add")));
+        addButton(new GuiButton(UNSET_BTN, guiLeft + 65, guiTop + 157, 47, 20, I18n.format(I18N_PREFIX + "unset")));
+        addButton(new GuiButton(WIPE_BTN, guiLeft + 118, guiTop + 157, 47, 20, I18n.format(I18N_PREFIX + "wipe")));
 
         updateButtons();
         tooltipSplitCache.clear();
         info = StreamSupport
                 .stream(
-                        Splitter.on("\\n").split(
-                                StatCollector.translateToLocal("item.structurelib.constructableTrigger.gui.info"))
-                                .spliterator(),
+                        Splitter.on("\\n").split(StatCollector.translateToLocal(I18N_PREFIX + "info")).spliterator(),
                         false)
                 .flatMap(line -> fontRendererObj.listFormattedStringToWidth(line, width * 3 / 5).stream())
                 .collect(Collectors.toList());
@@ -397,22 +374,10 @@ public class GuiScreenConfigureChannels extends GuiContainer implements IGuiScre
         int topLeftY = (this.height - this.getYSize()) / 2;
         drawTexturedModalRect(topLeftX, topLeftY, 0, 0, getXSize(), getYSize());
         list.drawScreen(mX, mY, partialTick);
-        fontRendererObj.drawString(
-                I18n.format("item.structurelib.constructableTrigger.gui.title"),
-                guiLeft + 12,
-                guiTop + 9,
-                0);
-        fontRendererObj.drawString(
-                I18n.format("item.structurelib.constructableTrigger.gui.key"),
-                guiLeft + 12,
-                guiTop + 122,
-                0);
+        fontRendererObj.drawString(I18n.format(I18N_PREFIX + "title"), guiLeft + 12, guiTop + 9, 0);
+        fontRendererObj.drawString(I18n.format(I18N_PREFIX + "key"), guiLeft + 12, guiTop + 122, 0);
         key.drawTextBox();
-        fontRendererObj.drawString(
-                I18n.format("item.structurelib.constructableTrigger.gui.value"),
-                guiLeft + 12,
-                guiTop + 142,
-                0);
+        fontRendererObj.drawString(I18n.format(I18N_PREFIX + "value"), guiLeft + 12, guiTop + 142, 0);
         value.drawTextBox();
     }
 
@@ -455,7 +420,7 @@ public class GuiScreenConfigureChannels extends GuiContainer implements IGuiScre
             tooltip.addAll(
                     fontRendererObj.listFormattedStringToWidth(
                             StatCollector.translateToLocalFormatted(
-                                    "item.structurelib.constructableTrigger.gui.channels.from",
+                                    I18N_PREFIX + "channels.from",
                                     Loader.instance().getIndexedModList().get(e.getKey()).getName()),
                             maxLine));
             tooltip.addAll(

--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -38,7 +38,7 @@ item.structurelib.constructableTrigger.gui.set=Update
 item.structurelib.constructableTrigger.gui.unset=Remove
 item.structurelib.constructableTrigger.gui.wipe=§4Clear
 item.structurelib.constructableTrigger.gui.channels.from=§rMod: §9§o%s
-item.structurelib.constructableTrigger.gui.info=Many multiblocks support some degree of variation in their structure and a sub channels allows indication of which variant to use.\n Sub channels are has a sequence of lowercase characters as key and a positive integer as value. Most known sub channels should be available as typeahead completions.\n You can also drag and drop items from NEI to set the corresponding sub channel value. These items all have a tooltip of "§oIndicates§r §ovalue§r §oX§r §ofor§r §osub§r §ochannel§r §oY§r".
+item.structurelib.constructableTrigger.gui.info=Many multiblocks support some degree of variation in their structure and a sub channel allows indication of which variant to use.\n All sub channels have a sequence of lowercase characters as key and a positive integer as value. Most known sub channels should be available as typeahead completions.\n You can also drag and drop items from NEI to set the corresponding sub channel value. These items all have a tooltip of "§oIndicates§r §ovalue§r §oX§r §ofor§r §osub§r §ochannel§r §oY§r".
 
 channels.structurelib.show_errors=When set, will highlight parts of the multiblock that is definitely wrong
 

--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -34,11 +34,11 @@ item.structurelib.constructableTrigger.gui.title=Sub Channels
 item.structurelib.constructableTrigger.gui.key=Key:
 item.structurelib.constructableTrigger.gui.value=Value:
 item.structurelib.constructableTrigger.gui.add=Add
-item.structurelib.constructableTrigger.gui.set=Set
-item.structurelib.constructableTrigger.gui.unset=Unset
-item.structurelib.constructableTrigger.gui.wipe=§4Wipe
+item.structurelib.constructableTrigger.gui.set=Update
+item.structurelib.constructableTrigger.gui.unset=Remove
+item.structurelib.constructableTrigger.gui.wipe=§4Clear
 item.structurelib.constructableTrigger.gui.channels.from=§rMod: §9§o%s
-item.structurelib.constructableTrigger.gui.info=Many multiblocks support some degree of variation in its structure and use sub channels to indicate which variant to use.\n Sub channels are has a sequence of lower case characters as key and a positive integer as value. Most known sub channels should be available as typeahead completions.\nYou can also drag and drop items from NEI to set the corresponding sub channel value. These items all have a tooltip of §oIndicates value X for sub channel Y§r.
+item.structurelib.constructableTrigger.gui.info=Many multiblocks support some degree of variation in their structure and a sub channels allows indication of which variant to use.\n Sub channels are has a sequence of lowercase characters as key and a positive integer as value. Most known sub channels should be available as typeahead completions.\n You can also drag and drop items from NEI to set the corresponding sub channel value. These items all have a tooltip of "§oIndicates§r §ovalue§r §oX§r §ofor§r §osub§r §ochannel§r §oY§r".
 
 channels.structurelib.show_errors=When set, will highlight parts of the multiblock that is definitely wrong
 


### PR DESCRIPTION
The channel GUI info tooltip was overflowing on smaller GUI scales. The tooltip is dynamically resized to the current screen width and the problem here was that at these small scales, the info button that shows the tooltip was essentially in the middle of the screen. The code reflowed the tooltip to 3/5 of the screen, so it was always too wide regardless of whether it was drawn left or right of the cursor . The change here is to keep the tooltip below half of the screen width.

Additionally, I did a small grammar and phrasing pass on the tooltip and renamed the GUI buttons from "Add", "Set", "Unset", and "Wipe" to "Add", "Update", "Remove", and "Clear", which I found more fitting.

Before:
<img width="1282" height="760" alt="2025-09-14_20 37 34" src="https://github.com/user-attachments/assets/7d5092ea-8be6-419c-ae61-0fe69e666ae4" />

After:
<img width="1142" height="710" alt="2025-09-14_20 43 40" src="https://github.com/user-attachments/assets/e463d734-8f85-4a70-9ea8-c906a602d0c1" />

At small GUI scale:
<img width="1142" height="710" alt="2025-09-14_20 44 09" src="https://github.com/user-attachments/assets/11919a50-d611-4e5c-b50d-76cc114a838c" />

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19627