### PR TITLE
Fix crash trying to open Hologram Projector GUI on java 8

### DIFF
--- a/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java
@@ -218,8 +218,7 @@ public class GuiScreenConfigureChannels extends GuiContainer implements IGuiScre
         actionPerformed(but);
     }
 
-    @SuppressWarnings("unchecked")
-    private List<GuiButton> getButtonList() {
+    public List<GuiButton> getButtonList() {
         return buttonList;
     }
 


### PR DESCRIPTION
There is a conflict between Structurelib and Inventory Bogo Sorter here that only manifests itself in java 8. Inventory Bogo Sorter provides the following [mixin](https://github.com/GTNewHorizons/InventoryBogoSorter/blob/41d705c0ba2154b9c5c4b1ad1e89df92073e4453/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/GuiScreenAccessor.java):

```java
@Mixin(GuiScreen.class)
public interface GuiScreenAccessor {
    @Accessor
    List<GuiButton> getButtonList();
    //...
}
```

In the code, it takes advantage of this interface in the following way:

```java
public void onDrawScreen(GuiScreenEvent.DrawScreenEvent.Post event) {
    //...
    for (GuiButton button : ((GuiScreenAccessor) event.gui).getButtonList()) {
        //...
    }
}
```

The problem arises in Structurelib's `GuiScreenConfigureChannels`, which is a subclass of `GuiScreen` and [defines](https://github.com/GTNewHorizons/StructureLib/blob/0030c02e9a7c71e3377b9dd4b7f28014891ee78e/src/main/java/com/gtnewhorizon/structurelib/gui/GuiScreenConfigureChannels.java#L222-L224) its own accessor method:

```java
private List<GuiButton> getButtonList() {
    return buttonList;
}
```

On java 8 this leads to the code in Inventory Bogo Sorter trying to call the private method in `GuiScreenConfigureChannels` and getting an `IllegalAccessException`. However, this same code works fine in java 21. The Inventory Bogo Sorter code calls the accessor method from the mixin and no exception gets thrown, all access is legal. I'm honestly not sure why there is a difference in behavior here between java versions. There are a couple of ways I can think of to fix the issue, but none of them feel optimal.

Alternatively, I could have renamed the accessor methods in the Inventory Bogo Sorter mixin to prevent a crash (to something like `bogo$getButtonList`), but it was recently changed specifically to remove the prefixes to reduce number of duplicated methods. See https://github.com/GTNewHorizons/InventoryBogoSorter/pull/111:

> use regular names for the mixin accessors so they can be merged with the accessors from other mods

I assume there is good intent behind this, so I decided to not fix this issue in Inventory Bogo Sorter.


fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21124