### PR TITLE
Add getDescription() to IStructureElement

### DIFF
--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
@@ -49,8 +49,8 @@ public interface IStructureElement<T> {
      * <p>
      * Unlike {@link #getBlocksToPlace}, which returns the full set of concrete block variants for autoplacing (e.g.
      * every tier of Input Bus), this method returns <b>category-level</b> descriptions suitable for display to the
-     * player (e.g. just "Input Bus"). It also requires no parameters, no world, trigger item, or environment, making
-     * it usable in contexts where those are unavailable.
+     * player (e.g. just "Input Bus"). It also requires no parameters, no world, trigger item, or environment, making it
+     * usable in contexts where those are unavailable.
      * <p>
      * Implementations should return <b>lang keys</b> (e.g. {@code "tile.blockGlass.name"}) rather than pre-translated
      * display names. The caller is responsible for translating these keys on the client side via

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
@@ -44,10 +44,16 @@ public interface IStructureElement<T> {
     }
 
     /**
-     * Returns a human-readable description of what block(s) this element accepts. Used for diagnostic messages when
-     * structure checks fail.
+     * Returns a description of what block(s) this element accepts. Used for diagnostic messages when structure checks
+     * fail.
+     * <p>
+     * Implementations should return <b>lang keys</b> (e.g. {@code "tile.blockGlass.name"}) rather than pre-translated
+     * display names. The caller is responsible for translating these keys on the client side via
+     * {@code StatCollector.translateToLocal()}. If a key has no matching translation, {@code translateToLocal} returns
+     * the input string unchanged, so pre-translated fallback strings also work.
      *
-     * @return a list of accepted block descriptions (e.g. display names), or null if no description is available
+     * @return a list of accepted block descriptions as lang keys (or display names as fallback), or null if no
+     *         description is available
      */
     @Nullable
     default List<String> getDescription() {

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
@@ -5,6 +5,7 @@ import static com.gtnewhorizon.structurelib.StructureLib.PANIC_MODE;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -40,6 +41,17 @@ public interface IStructureElement<T> {
      */
     default boolean couldBeValid(T t, World world, int x, int y, int z, ItemStack trigger) {
         return true;
+    }
+
+    /**
+     * Returns a human-readable description of what block(s) this element accepts. Used for diagnostic messages when
+     * structure checks fail.
+     *
+     * @return a list of accepted block descriptions (e.g. display names), or null if no description is available
+     */
+    @Nullable
+    default List<String> getDescription() {
+        return null;
     }
 
     boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger);
@@ -203,6 +215,12 @@ public interface IStructureElement<T> {
             @Override
             public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return IStructureElement.this.spawnHint(t, world, x, y, z, trigger);
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return IStructureElement.this.getDescription();
             }
         };
     }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
@@ -44,8 +44,13 @@ public interface IStructureElement<T> {
     }
 
     /**
-     * Returns a description of what block(s) this element accepts. Used for diagnostic messages when structure checks
-     * fail.
+     * Returns a human-readable description of what block(s) this element accepts. Used for diagnostic messages when
+     * structure checks fail (e.g. "expected Input Bus at (1, 2, 3)").
+     * <p>
+     * Unlike {@link #getBlocksToPlace}, which returns the full set of concrete block variants for autoplacing (e.g.
+     * every tier of Input Bus), this method returns <b>category-level</b> descriptions suitable for display to the
+     * player (e.g. just "Input Bus"). It also requires no parameters, no world, trigger item, or environment, making
+     * it usable in contexts where those are unavailable.
      * <p>
      * Implementations should return <b>lang keys</b> (e.g. {@code "tile.blockGlass.name"}) rather than pre-translated
      * display names. The caller is responsible for translating these keys on the client side via

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
@@ -1,7 +1,9 @@
 package com.gtnewhorizon.structurelib.structure;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -59,6 +61,19 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
             }
         }
         return false;
+    }
+
+    @Nullable
+    @Override
+    default List<String> getDescription() {
+        Set<String> descriptions = new LinkedHashSet<>();
+        for (IStructureElement<T> fallback : fallbacks()) {
+            List<String> desc = fallback.getDescription();
+            if (desc != null) {
+                descriptions.addAll(desc);
+            }
+        }
+        return descriptions.isEmpty() ? null : new ArrayList<>(descriptions);
     }
 
     @Nullable

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
@@ -67,9 +67,8 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
     @Override
     default List<String> getDescription() {
         Set<String> descriptions = new LinkedHashSet<>();
-        IStructureElement<T>[] elements = fallbacks();
-        for (int i = elements.length - 1; i >= 0; i--) {
-            List<String> desc = elements[i].getDescription();
+        for (IStructureElement<T> fallback : fallbacks()) {
+            List<String> desc = fallback.getDescription();
             if (desc != null) {
                 descriptions.addAll(desc);
             }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
@@ -67,8 +67,9 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
     @Override
     default List<String> getDescription() {
         Set<String> descriptions = new LinkedHashSet<>();
-        for (IStructureElement<T> fallback : fallbacks()) {
-            List<String> desc = fallback.getDescription();
+        IStructureElement<T>[] elements = fallbacks();
+        for (int i = elements.length - 1; i >= 0; i--) {
+            List<String> desc = elements[i].getDescription();
             if (desc != null) {
                 descriptions.addAll(desc);
             }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/LazyStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/LazyStructureElement.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.structurelib.structure;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -64,5 +65,11 @@ class LazyStructureElement<T> implements IStructureElementDeferred<T> {
     public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
             AutoPlaceEnvironment env) {
         return get(t).survivalPlaceBlock(t, world, x, y, z, trigger, env);
+    }
+
+    @Nullable
+    @Override
+    public List<String> getDescription() {
+        return elem != null ? elem.getDescription() : null;
     }
 }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -1413,8 +1413,8 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections
-                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, meta).getDisplayName());
+                    return Collections.singletonList(
+                            new ItemStack(Item.getItemFromBlock(block), 1, meta).getUnlocalizedName() + ".name");
                 }
             };
         } else {
@@ -1499,8 +1499,8 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections
-                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, meta).getDisplayName());
+                    return Collections.singletonList(
+                            new ItemStack(Item.getItemFromBlock(block), 1, meta).getUnlocalizedName() + ".name");
                 }
             };
         }
@@ -1548,8 +1548,8 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections
-                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, 0).getDisplayName());
+                    return Collections.singletonList(
+                            new ItemStack(Item.getItemFromBlock(block), 1, 0).getUnlocalizedName() + ".name");
                 }
             };
         } else {
@@ -1587,8 +1587,8 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections
-                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, 0).getDisplayName());
+                    return Collections.singletonList(
+                            new ItemStack(Item.getItemFromBlock(block), 1, 0).getUnlocalizedName() + ".name");
                 }
             };
         }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -785,6 +785,7 @@ public class StructureUtility {
                         env.getActor(),
                         env.getChatter());
             }
+
         };
     }
 
@@ -1408,6 +1409,13 @@ public class StructureUtility {
                         AutoPlaceEnvironment env) {
                     return BlocksToPlace.create(block, meta);
                 }
+
+                @Nullable
+                @Override
+                public List<String> getDescription() {
+                    return Collections
+                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, meta).getDisplayName());
+                }
             };
         } else {
             return new IStructureElement<T>() {
@@ -1487,6 +1495,13 @@ public class StructureUtility {
                         AutoPlaceEnvironment env) {
                     return BlocksToPlace.create(block, meta);
                 }
+
+                @Nullable
+                @Override
+                public List<String> getDescription() {
+                    return Collections
+                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, meta).getDisplayName());
+                }
             };
         }
     }
@@ -1529,6 +1544,13 @@ public class StructureUtility {
                     // there is getSubItems on ItemBlock, but it's client only
                     return BlocksToPlace.create(defaultBlock, defaultMeta);
                 }
+
+                @Nullable
+                @Override
+                public List<String> getDescription() {
+                    return Collections
+                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, 0).getDisplayName());
+                }
             };
         } else {
             return new IStructureElement<T>() {
@@ -1560,6 +1582,13 @@ public class StructureUtility {
                         AutoPlaceEnvironment env) {
                     // there is getSubItems on ItemBlock, but it's client only
                     return BlocksToPlace.create(defaultBlock, defaultMeta);
+                }
+
+                @Nullable
+                @Override
+                public List<String> getDescription() {
+                    return Collections
+                            .singletonList(new ItemStack(Item.getItemFromBlock(block), 1, 0).getDisplayName());
                 }
             };
         }
@@ -1824,6 +1853,71 @@ public class StructureUtility {
                     AutoPlaceEnvironment env) {
                 return element.survivalPlaceBlock(t, world, x, y, z, trigger, env);
             }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return element.getDescription();
+            }
+        };
+    }
+
+    /**
+     * Wraps an element and overrides its description. Useful for providing human-readable names to elements whose
+     * underlying implementation doesn't provide a description (e.g. tiered block elements).
+     *
+     * @param description the description to use, or null to clear any existing description
+     * @param element     the element to wrap
+     */
+    public static <B extends IStructureElement<T>, T> IStructureElement<T> withDescription(
+            @Nullable List<String> description, B element) {
+        return new IStructureElement<T>() {
+
+            @Override
+            public boolean check(T t, World world, int x, int y, int z) {
+                return element.check(t, world, x, y, z);
+            }
+
+            @Override
+            public boolean couldBeValid(T t, World world, int x, int y, int z, ItemStack trigger) {
+                return element.couldBeValid(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
+                return element.placeBlock(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
+                return element.spawnHint(t, world, x, y, z, trigger);
+            }
+
+            @Nullable
+            @Override
+            public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
+                    AutoPlaceEnvironment env) {
+                return element.getBlocksToPlace(t, world, x, y, z, trigger, env);
+            }
+
+            @Override
+            @Deprecated
+            public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
+                    IItemSource s, EntityPlayerMP actor, Consumer<IChatComponent> chatter) {
+                return element.survivalPlaceBlock(t, world, x, y, z, trigger, s, actor, chatter);
+            }
+
+            @Override
+            public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
+                    AutoPlaceEnvironment env) {
+                return element.survivalPlaceBlock(t, world, x, y, z, trigger, env);
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return description;
+            }
         };
     }
 
@@ -1879,6 +1973,12 @@ public class StructureUtility {
             public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
                     AutoPlaceEnvironment env) {
                 return element.survivalPlaceBlock(t, world, x, y, z, trigger, env);
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return element.getDescription();
             }
         };
     }
@@ -1948,6 +2048,12 @@ public class StructureUtility {
                     AutoPlaceEnvironment env) {
                 if (predicate.test(t)) return downstream.survivalPlaceBlock(t, world, x, y, z, trigger, env);
                 return placeResultWhenDisabled;
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return downstream.getDescription();
             }
         };
     }
@@ -2045,6 +2151,12 @@ public class StructureUtility {
             public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
                     AutoPlaceEnvironment env) {
                 return elem.survivalPlaceBlock(t.getCurrentContext(), world, x, y, z, trigger, env);
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return elem.getDescription();
             }
         };
     }
@@ -2882,6 +2994,12 @@ public class StructureUtility {
                     // instead of some false positive error messages like item not find
                     warnNoExplicitSubChannel(env.getActor());
                 return backing.survivalPlaceBlock(t, world, x, y, z, newTrigger, env);
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return backing.getDescription();
             }
         };
     }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -1413,8 +1413,9 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections.singletonList(
-                            new ItemStack(Item.getItemFromBlock(block), 1, meta).getUnlocalizedName() + ".name");
+                    Item item = Item.getItemFromBlock(block);
+                    if (item == null) return null;
+                    return Collections.singletonList(new ItemStack(item, 1, meta).getUnlocalizedName() + ".name");
                 }
             };
         } else {
@@ -1499,8 +1500,9 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections.singletonList(
-                            new ItemStack(Item.getItemFromBlock(block), 1, meta).getUnlocalizedName() + ".name");
+                    Item item = Item.getItemFromBlock(block);
+                    if (item == null) return null;
+                    return Collections.singletonList(new ItemStack(item, 1, meta).getUnlocalizedName() + ".name");
                 }
             };
         }
@@ -1548,8 +1550,9 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections.singletonList(
-                            new ItemStack(Item.getItemFromBlock(block), 1, 0).getUnlocalizedName() + ".name");
+                    Item item = Item.getItemFromBlock(block);
+                    if (item == null) return null;
+                    return Collections.singletonList(new ItemStack(item, 1, 0).getUnlocalizedName() + ".name");
                 }
             };
         } else {
@@ -1587,8 +1590,9 @@ public class StructureUtility {
                 @Nullable
                 @Override
                 public List<String> getDescription() {
-                    return Collections.singletonList(
-                            new ItemStack(Item.getItemFromBlock(block), 1, 0).getUnlocalizedName() + ".name");
+                    Item item = Item.getItemFromBlock(block);
+                    if (item == null) return null;
+                    return Collections.singletonList(new ItemStack(item, 1, 0).getUnlocalizedName() + ".name");
                 }
             };
         }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -707,6 +707,19 @@ public class StructureUtility {
     public static <T, TIER> IStructureElement<T> ofBlocksTiered(ITierConverter<TIER> tierExtractor,
             @Nullable List<Pair<Block, Integer>> allKnownTiers, @Nullable TIER notSet, BiConsumer<T, TIER> setter,
             Function<T, TIER> getter) {
+        return ofBlocksTiered(tierExtractor, allKnownTiers, notSet, setter, getter, null);
+    }
+
+    /**
+     * Like {@link #ofBlocksTiered(ITierConverter, List, Object, BiConsumer, Function)}, but with an explicit
+     * description that will be returned by {@link IStructureElement#getDescription()}.
+     *
+     * @param description the description lang keys to attach to this element, or null for no description
+     * @see #ofBlocksTiered(ITierConverter, List, Object, BiConsumer, Function)
+     */
+    public static <T, TIER> IStructureElement<T> ofBlocksTiered(ITierConverter<TIER> tierExtractor,
+            @Nullable List<Pair<Block, Integer>> allKnownTiers, @Nullable TIER notSet, BiConsumer<T, TIER> setter,
+            Function<T, TIER> getter, @Nullable List<String> description) {
         List<Pair<Block, Integer>> hints = allKnownTiers == null ? Collections.emptyList() : allKnownTiers;
         if (hints.stream().anyMatch(Objects::isNull)) throw new IllegalArgumentException();
         IStructureElementCheckOnly<T> check = ofBlocksTiered(tierExtractor, notSet, setter, getter);
@@ -784,6 +797,12 @@ public class StructureUtility {
                         env.getSource(),
                         env.getActor(),
                         env.getChatter());
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription() {
+                return description;
             }
 
         };


### PR DESCRIPTION
Adds a getDescription() default method to IStructureElement that returns an optional list of human-readable names describing which blocks the element accepts. This lets consumers (like GT5) show enriched diagnostics when a multiblock structure check fails, telling the player which block is expected at a given position.

Also adds a withDescription() wrapper in StructureUtility and delegates it through IStructureElementChain, LazyStructureElement, and all wrapper methods (onElementPass, onElementFail, withChannel, withContext, onlyIf).

All changes are non-breaking: existing implementations inherit a default that returns null.