### PR TITLE
Add fluid block autoplace with a pluggable fluid cost and source API

### DIFF
--- a/src/main/java/com/gtnewhorizon/structurelib/ConfigurationHandler.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/ConfigurationHandler.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.gtnewhorizon.structurelib.structure.FluidAutoplace;
 
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -33,6 +34,8 @@ public enum ConfigurationHandler {
     private int hintTransparency;
     private int autoPlaceBudget;
     private int autoPlaceInterval;
+    private boolean fluidAutoplace = true;
+    private FluidAutoplace.GateMode fluidGateMode = FluidAutoplace.GateMode.STRICT;
     private Map<String, Pair<List<String>, List<String>>> registryOrders;
 
     ConfigurationHandler() {
@@ -97,10 +100,34 @@ public enum ConfigurationHandler {
                         + "As expected, server side settings will overrides client settings.\n"
                         + "Note this relates to the wall clock, not in game ticks.\n"
                         + "Value smaller than default is likely to be perceived as no minimal interval whatsoever.");
+        fluidAutoplace = config.getBoolean(
+                "fluidAutoplace",
+                "common.autoplace",
+                true,
+                "Whether survival autoplace may place fluid blocks, e.g. the water a multiblock needs inside itself, by draining fluid from the player's fluid containers.\n"
+                        + "A multiblock can also provide its own fluid source, see IFluidSource.\n"
+                        + "This only disables fluid blocks. Multiblocks keep working, they just cannot have those positions filled by autoplace.");
+        fluidGateMode = readFluidGateMode();
 
         loadRegistryOrder();
 
         saveConfig();
+    }
+
+    private FluidAutoplace.GateMode readFluidGateMode() {
+        String value = config.getString(
+                "fluidGateMode",
+                "common.autoplace",
+                FluidAutoplace.GateMode.STRICT.name(),
+                "How careful autoplace is about placing a fluid into a structure that is not finished yet, as a fluid would flow out of it.\n"
+                        + "NONE: place the fluid right away.\n"
+                        + "LENIENT: only place the fluid when it cannot flow out of the structure.\n"
+                        + "STRICT: only place the fluid once every non fluid element of the structure is satisfied. Note that this makes a fluid at worst one auto place round late.");
+        for (FluidAutoplace.GateMode mode : FluidAutoplace.GateMode.values()) {
+            if (mode.name().equalsIgnoreCase(value)) return mode;
+        }
+        StructureLib.LOGGER.warn("Unknown fluidGateMode '{}', falling back to STRICT", value);
+        return FluidAutoplace.GateMode.STRICT;
     }
 
     void loadRegistryOrder() {
@@ -174,6 +201,20 @@ public enum ConfigurationHandler {
 
     public int getAutoPlaceInterval() {
         return autoPlaceInterval;
+    }
+
+    /**
+     * Whether survival autoplace may place fluid blocks by draining fluid from a fluid source.
+     */
+    public boolean isFluidAutoplaceEnabled() {
+        return fluidAutoplace;
+    }
+
+    /**
+     * How careful autoplace is about placing a fluid into a structure that is not finished yet.
+     */
+    public FluidAutoplace.GateMode getFluidGateMode() {
+        return fluidGateMode;
     }
 
     public Pair<List<String>, List<String>> getRegistryOrder(String name) {

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLib.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLib.java
@@ -23,9 +23,9 @@ import org.apache.logging.log4j.Logger;
 import com.gtnewhorizon.structurelib.block.BlockHint;
 import com.gtnewhorizon.structurelib.command.CommandConfigureChannels;
 import com.gtnewhorizon.structurelib.command.CommandRegistryDebug;
-import com.gtnewhorizon.structurelib.fluid.FluidContainerExtractors;
 import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
 import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
+import com.gtnewhorizon.structurelib.fluid.FluidStackExtractors;
 import com.gtnewhorizon.structurelib.item.ItemBlockHint;
 import com.gtnewhorizon.structurelib.item.ItemConstructableTrigger;
 import com.gtnewhorizon.structurelib.item.ItemFrontRotationTool;
@@ -116,7 +116,7 @@ public class StructureLib {
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent e) {
         InventoryUtility.init();
-        FluidContainerExtractors.init();
+        FluidStackExtractors.init();
         FluidSourceProviders.init();
         FluidPlacementRegistry.init();
         ConfigurationHandler.INSTANCE.init(e.getSuggestedConfigurationFile());

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLib.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLib.java
@@ -13,6 +13,9 @@ import net.minecraft.launchwrapper.Launch;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,6 +23,9 @@ import org.apache.logging.log4j.Logger;
 import com.gtnewhorizon.structurelib.block.BlockHint;
 import com.gtnewhorizon.structurelib.command.CommandConfigureChannels;
 import com.gtnewhorizon.structurelib.command.CommandRegistryDebug;
+import com.gtnewhorizon.structurelib.fluid.FluidContainerExtractors;
+import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
+import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
 import com.gtnewhorizon.structurelib.item.ItemBlockHint;
 import com.gtnewhorizon.structurelib.item.ItemConstructableTrigger;
 import com.gtnewhorizon.structurelib.item.ItemFrontRotationTool;
@@ -109,6 +115,10 @@ public class StructureLib {
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent e) {
+        InventoryUtility.init();
+        FluidContainerExtractors.init();
+        FluidSourceProviders.init();
+        FluidPlacementRegistry.init();
         ConfigurationHandler.INSTANCE.init(e.getSuggestedConfigurationFile());
         GameRegistry.registerBlock(blockHint = new BlockHint(), ItemBlockHint.class, "blockhint");
         itemBlockHint = ItemBlock.getItemFromBlock(StructureLibAPI.getBlockHint());
@@ -120,8 +130,6 @@ public class StructureLib {
                 itemConstructableTrigger.getUnlocalizedName());
         proxy.preInit(e);
         NetworkRegistry.INSTANCE.registerGuiHandler(instance(), new GuiHandler());
-
-        InventoryUtility.init();
 
         ChannelDescription.set(CHANNEL_SHOW_ERROR, MOD_ID, "channels.structurelib.show_errors");
 
@@ -149,7 +157,49 @@ public class StructureLib {
                 case "register_channel_item":
                     processRegisterChannelItem(message);
                     break;
+                case "register_fluid_block_cost":
+                    processRegisterFluidBlockCost(message);
+                    break;
             }
+        }
+    }
+
+    /**
+     * Teach StructureLib what it costs to place a fluid block, without having to link against StructureLib.
+     * <p>
+     * The message must hold a compound with {@code Block} (registry name), {@code Fluid} (fluid name), optionally
+     * {@code Meta} (default 0), {@code Amount} (default one bucket) and {@code ForceFluid} (default false).
+     */
+    private void processRegisterFluidBlockCost(FMLInterModComms.IMCMessage message) {
+        if (!message.isNBTMessage()) {
+            LOGGER.warn("{} sent a register_fluid_block_cost message without any data", message.getSender());
+            return;
+        }
+        NBTTagCompound tag = message.getNBTValue();
+        String blockName = tag.getString("Block");
+        String fluidName = tag.getString("Fluid");
+        Object block = Block.blockRegistry.getObject(blockName);
+        Fluid fluid = FluidRegistry.getFluid(fluidName);
+        if (!(block instanceof Block)) {
+            LOGGER.warn("{} tried to register a fluid block cost for unknown block {}", message.getSender(), blockName);
+            return;
+        }
+        if (fluid == null) {
+            LOGGER.warn("{} tried to register a fluid block cost for unknown fluid {}", message.getSender(), fluidName);
+            return;
+        }
+        int meta = tag.getInteger("Meta");
+        int amount = tag.hasKey("Amount") ? tag.getInteger("Amount") : FluidPlacementRegistry.DEFAULT_FLUID_AMOUNT;
+        boolean forceFluid = tag.getBoolean("ForceFluid");
+        try {
+            FluidPlacementRegistry.register((Block) block, meta, new FluidStack(fluid, amount), forceFluid);
+        } catch (IllegalArgumentException e) {
+            // never let a badly formed message from another mod break the game
+            LOGGER.warn(
+                    "{} tried to register a fluid block cost for {}:{} twice",
+                    message.getSender(),
+                    blockName,
+                    meta);
         }
     }
 

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
@@ -17,10 +17,10 @@ import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentProvider;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.fluid.FluidBlockPlacement;
-import com.gtnewhorizon.structurelib.fluid.FluidContainerExtractor;
-import com.gtnewhorizon.structurelib.fluid.FluidContainerExtractors;
 import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
 import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
+import com.gtnewhorizon.structurelib.fluid.FluidStackExtractor;
+import com.gtnewhorizon.structurelib.fluid.FluidStackExtractors;
 import com.gtnewhorizon.structurelib.fluid.IFluidSourceProvider;
 import com.gtnewhorizon.structurelib.net.AlignmentMessage;
 import com.gtnewhorizon.structurelib.structure.AutoPlaceEnvironment;
@@ -421,8 +421,8 @@ public class StructureLibAPI {
      * @param key       unique key. Matches the key shown in the config gui.
      * @param extractor the extractor
      */
-    public static void registerFluidContainerExtractor(String key, FluidContainerExtractor extractor) {
-        FluidContainerExtractors.register(key, extractor);
+    public static void registerFluidStackExtractor(String key, FluidStackExtractor extractor) {
+        FluidStackExtractors.register(key, extractor);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
@@ -10,11 +10,18 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler;
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentProvider;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockPlacement;
+import com.gtnewhorizon.structurelib.fluid.FluidContainerExtractor;
+import com.gtnewhorizon.structurelib.fluid.FluidContainerExtractors;
+import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
+import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
+import com.gtnewhorizon.structurelib.fluid.IFluidSourceProvider;
 import com.gtnewhorizon.structurelib.net.AlignmentMessage;
 import com.gtnewhorizon.structurelib.structure.AutoPlaceEnvironment;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -362,6 +369,76 @@ public class StructureLibAPI {
      */
     public static void registerChannelDescription(final String channel, final String modid, final String description) {
         ChannelDescription.set(channel, modid, description);
+    }
+
+    /**
+     * Register what it costs to place a fluid block, and how to place it.
+     * <p>
+     * Water and lava are registered by default, and every Forge fluid block is recognised automatically, so this is
+     * only needed for a fluid block that costs something else than one bucket, for a fluid block that has to be written
+     * into the world in a special way, or for a block that has an item form but should always be paid for with fluid.
+     *
+     * @param block     the fluid block
+     * @param meta      the block meta. {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} covers every
+     *                  meta of this block.
+     * @param placement what this block state costs and how to place it
+     */
+    public static void registerFluidBlockCost(Block block, int meta, FluidBlockPlacement placement) {
+        FluidPlacementRegistry.register(block, meta, placement);
+    }
+
+    /**
+     * Register what it costs to place a fluid block, preferring the item form when the block has one.
+     *
+     * @param block the fluid block
+     * @param meta  the block meta
+     * @param cost  how much fluid one block of this state costs
+     * @see #registerFluidBlockCost(Block, int, FluidBlockPlacement)
+     */
+    public static void registerFluidBlockCost(Block block, int meta, FluidStack cost) {
+        FluidPlacementRegistry.register(block, meta, cost);
+    }
+
+    /**
+     * Register what it costs to place a fluid block.
+     *
+     * @param block      the fluid block
+     * @param meta       the block meta
+     * @param cost       how much fluid one block of this state costs
+     * @param forceFluid whether to always pay with fluid, even when this block also has an item form
+     * @see #registerFluidBlockCost(Block, int, FluidBlockPlacement)
+     */
+    public static void registerFluidBlockCost(Block block, int meta, FluidStack cost, boolean forceFluid) {
+        FluidPlacementRegistry.register(block, meta, cost, forceFluid);
+    }
+
+    /**
+     * Register a way to pull fluid out of an item, so that autoplace can pay for a fluid block with it.
+     * <p>
+     * Forge's fluid container item and Forge's fluid container registry are both supported out of the box, which covers
+     * buckets and most modded cells. Register your own extractor for a container that exposes its fluid by other means.
+     *
+     * @param key       unique key. Matches the key shown in the config gui.
+     * @param extractor the extractor
+     */
+    public static void registerFluidContainerExtractor(String key, FluidContainerExtractor extractor) {
+        FluidContainerExtractors.register(key, extractor);
+    }
+
+    /**
+     * Register a way to hand StructureLib fluid without the player having to carry a fluid container, e.g. the ME
+     * network behind a wireless terminal the player has on them.
+     * <p>
+     * Providers are asked before the fluid containers the player is carrying, in the order the player configured, so
+     * the player can reorder or disable every provider in StructureLib's config. A provider should look up what it
+     * drains from every time it is asked for fluid rather than when it is created, as the player can walk out of range
+     * or put a terminal away between two rounds of autoplace.
+     *
+     * @param key      unique key. Matches the key shown in the config gui.
+     * @param provider the provider
+     */
+    public static void registerFluidSourceProvider(String key, IFluidSourceProvider provider) {
+        FluidSourceProviders.register(key, provider);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
@@ -17,6 +17,7 @@ import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentProvider;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.fluid.FluidBlockPlacement;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockPlacer;
 import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
 import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
 import com.gtnewhorizon.structurelib.fluid.FluidStackExtractor;
@@ -410,6 +411,66 @@ public class StructureLibAPI {
      */
     public static void registerFluidBlockCost(Block block, int meta, FluidStack cost, boolean forceFluid) {
         FluidPlacementRegistry.register(block, meta, cost, forceFluid);
+    }
+
+    /**
+     * Register what it costs to place a fluid block, with {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of the
+     * fluid the block holds, preferring the item form when the block has one.
+     * <p>
+     * The amount is the whole cost of that state, so a block whose meta says how full it is wants one registration per
+     * meta it can be in, or no registration at all, in which case the default amount is scaled down for a partially
+     * filled position.
+     *
+     * @param block the fluid block
+     * @param meta  the block meta. {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} covers every meta of
+     *              this block.
+     * @throws IllegalArgumentException if the block holds no fluid, or this state is already registered
+     * @see #registerFluidBlockCost(Block, int, FluidBlockPlacement)
+     */
+    public static void registerFluidBlockCost(Block block, int meta) {
+        FluidPlacementRegistry.register(block, meta);
+    }
+
+    /**
+     * Register what it costs to place a fluid block, with {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of the
+     * fluid the block holds.
+     *
+     * @param block      the fluid block
+     * @param meta       the block meta. {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} covers every
+     *                   meta of this block.
+     * @param forceFluid whether to always pay with fluid, even when this block also has an item form
+     * @see #registerFluidBlockCost(Block, int)
+     */
+    public static void registerFluidBlockCost(Block block, int meta, boolean forceFluid) {
+        FluidPlacementRegistry.register(block, meta, forceFluid);
+    }
+
+    /**
+     * Register the whole block, i.e. every meta of it that has no registration of its own, with
+     * {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of the fluid it holds.
+     *
+     * @param block the fluid block
+     * @see #registerFluidBlockCost(Block, int)
+     */
+    public static void registerFluidBlockCost(Block block) {
+        FluidPlacementRegistry.register(block);
+    }
+
+    /**
+     * Register what it costs to place a fluid block, with {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of the
+     * fluid the block holds, and placed the way the given placer says.
+     * <p>
+     * Use this for a fluid block that cannot be placed with a plain block set, e.g. one that has to be filled through
+     * its own API.
+     *
+     * @param block  the fluid block
+     * @param meta   the block meta. {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} covers every meta
+     *               of this block.
+     * @param placer how to write the block into the world
+     * @see #registerFluidBlockCost(Block, int, FluidBlockPlacement)
+     */
+    public static void registerFluidBlockCost(Block block, int meta, FluidBlockPlacer placer) {
+        FluidPlacementRegistry.register(block, meta, placer);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/StructureLibAPI.java
@@ -2,6 +2,8 @@ package com.gtnewhorizon.structurelib;
 
 import static com.gtnewhorizon.structurelib.StructureLib.proxy;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -326,6 +328,26 @@ public class StructureLibAPI {
         // TODO extend this function a bit
         Block block = w.getBlock(x, y, z);
         return block.isAir(w, x, y, z) || block.isReplaceable(w, x, y, z);
+    }
+
+    /**
+     * Put back the block that was at a position, which is what a placement that could not be paid for should roll back
+     * to.
+     * <p>
+     * Restoring the previous state instead of clearing the position matters whenever the position held something
+     * autoplace is allowed to replace, e.g. a fluid that is not a source block: the player would otherwise be left with
+     * a hole where their fluid used to be.
+     *
+     * @param world world to write to
+     * @param x     x coord
+     * @param y     y coord
+     * @param z     z coord
+     * @param block the block that was there, or null for air
+     * @param meta  the meta that was there
+     */
+    public static void restoreBlock(World world, int x, int y, int z, @Nullable Block block, int meta) {
+        if (block == null || block.isAir(world, x, y, z)) world.setBlockToAir(x, y, z);
+        else world.setBlock(x, y, z, block, meta, 3);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/alignment/constructable/ConstructableUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/alignment/constructable/ConstructableUtility.java
@@ -16,6 +16,7 @@ import com.gtnewhorizon.structurelib.StructureLib;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
 import com.gtnewhorizon.structurelib.structure.IItemSource;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 
@@ -79,7 +80,13 @@ public class ConstructableUtility {
                 int built = ((ISurvivalConstructable) constructable).survivalConstruct(
                         aStack,
                         ConfigurationHandler.INSTANCE.getAutoPlaceBudget(),
-                        ISurvivalBuildEnvironment.create(IItemSource.fromPlayer(playerMP), playerMP));
+                        ISurvivalBuildEnvironment.create(
+                                IItemSource.fromPlayer(playerMP),
+                                // What the player can offer: every registered fluid source provider, e.g. the ME
+                                // network
+                                // behind a wireless terminal they have on them, and then the fluid they are carrying.
+                                FluidSourceProviders.getSourceFor(playerMP),
+                                playerMP));
                 if (built > 0) {
                     playerMP.addChatMessage(new ChatComponentTranslation("structurelib.autoplace.built_stat", built));
                 } else if (built == -1) {

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidAmounts.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidAmounts.java
@@ -1,0 +1,66 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.BlockFluidFinite;
+import net.minecraftforge.fluids.IFluidBlock;
+
+/**
+ * Measure how much fluid a block in the world holds.
+ * <p>
+ * Fluid blocks disagree on what their meta means. A vanilla style liquid counts down as it thins out, some modded
+ * fluids count up instead, and a Forge fluid block can report its own fill. These helpers hide that difference, which
+ * is what allows autoplace to charge only for the fluid that is actually missing from a position.
+ */
+public class FluidAmounts {
+
+    private FluidAmounts() {}
+
+    /**
+     * How much fluid a block of given meta holds, assuming it is a fluid block whose meta encodes a level.
+     * <p>
+     * Blocks implementing Forge's {@code IFluidBlock} answer this themselves once they are in the world, so this is
+     * only used to derive a cost for a state that is not in the world yet.
+     *
+     * @param block      the fluid block. Must not be null.
+     * @param meta       the meta to interpret
+     * @param fullAmount how much fluid a full block of this fluid holds
+     * @return amount of fluid, between 0 and {@code fullAmount} inclusive
+     */
+    public static int getAmountForMeta(Block block, int meta, int fullAmount) {
+        if (block == null) throw new IllegalArgumentException();
+        int level = meta & 7;
+        // A finite fluid counts up: meta 0 is the thinnest state, meta 7 is a full block.
+        if (block instanceof BlockFluidFinite) return fullAmount * (level + 1) / 8;
+        // Everything else counts down: meta 0 is a source block, meta 7 is the thinnest state.
+        return fullAmount * (8 - level) / 8;
+    }
+
+    /**
+     * How full the block at given position is, as a fraction of a full block.
+     *
+     * @return a fraction between 0 and 1 inclusive. 0 when the position does not hold a fluid block.
+     */
+    public static float getStoredFraction(World world, int x, int y, int z) {
+        Block block = world.getBlock(x, y, z);
+        if (block == null) return 0;
+        if (block instanceof IFluidBlock fluidBlock) {
+            // A negative percentage means the block fills from the top down. Only its magnitude is interesting here.
+            return Math.min(1f, Math.abs(fluidBlock.getFilledPercentage(world, x, y, z)));
+        }
+        if (block.getMaterial() != null && block.getMaterial().isLiquid()) {
+            return getAmountForMeta(block, world.getBlockMetadata(x, y, z), 8) / 8f;
+        }
+        return 0;
+    }
+
+    /**
+     * How much fluid the block at given position holds.
+     *
+     * @param capacity how much fluid a full block of this kind holds, i.e. the amount to scale the fill fraction by
+     * @return amount of fluid, between 0 and {@code capacity} inclusive
+     */
+    public static int getStoredAmount(World world, int x, int y, int z, int capacity) {
+        return Math.round(getStoredFraction(world, x, y, z) * capacity);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockPlacement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockPlacement.java
@@ -2,6 +2,7 @@ package com.gtnewhorizon.structurelib.fluid;
 
 import javax.annotation.Nullable;
 
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.github.bsideup.jabel.Desugar;
@@ -38,5 +39,66 @@ public record FluidBlockPlacement(FluidStack cost, boolean forceFluid, @Nullable
      */
     public static FluidBlockPlacement forced(FluidStack cost) {
         return new FluidBlockPlacement(cost, true, null);
+    }
+
+    /**
+     * A placement that pays {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of given fluid, prefers the item form
+     * when there is one, and places the block directly.
+     */
+    public static FluidBlockPlacement of(Fluid fluid) {
+        return of(defaultCost(fluid));
+    }
+
+    /**
+     * A placement that pays {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of given fluid, and always pays with
+     * fluid even when the block has an item form.
+     */
+    public static FluidBlockPlacement forced(Fluid fluid) {
+        return forced(defaultCost(fluid));
+    }
+
+    /**
+     * A placement that pays with given fluid, and writes the block into the world the way the given placer says.
+     * <p>
+     * Use this for a fluid block that cannot be placed with a plain block set, e.g. one that has to be filled through
+     * its own API.
+     */
+    public static FluidBlockPlacement of(FluidStack cost, @Nullable FluidBlockPlacer placer) {
+        return new FluidBlockPlacement(cost, false, placer);
+    }
+
+    /**
+     * A placement that pays with given fluid, always pays with fluid, and writes the block into the world the way the
+     * given placer says.
+     */
+    public static FluidBlockPlacement forced(FluidStack cost, @Nullable FluidBlockPlacer placer) {
+        return new FluidBlockPlacement(cost, true, placer);
+    }
+
+    /**
+     * A placement that pays {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of given fluid, and writes the block
+     * into the world the way the given placer says.
+     */
+    public static FluidBlockPlacement of(Fluid fluid, @Nullable FluidBlockPlacer placer) {
+        return of(defaultCost(fluid), placer);
+    }
+
+    /**
+     * A placement that pays {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of given fluid, always pays with fluid,
+     * and writes the block into the world the way the given placer says.
+     */
+    public static FluidBlockPlacement forced(Fluid fluid, @Nullable FluidBlockPlacer placer) {
+        return forced(defaultCost(fluid), placer);
+    }
+
+    /**
+     * What one block of given fluid costs unless something else was registered for it, which is one bucket.
+     *
+     * @param fluid the fluid to pay with
+     * @throws IllegalArgumentException if the fluid is null
+     */
+    public static FluidStack defaultCost(Fluid fluid) {
+        if (fluid == null) throw new IllegalArgumentException("fluid must not be null");
+        return new FluidStack(fluid, FluidPlacementRegistry.DEFAULT_FLUID_AMOUNT);
     }
 }

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockPlacement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockPlacement.java
@@ -1,0 +1,42 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import javax.annotation.Nullable;
+
+import net.minecraftforge.fluids.FluidStack;
+
+import com.github.bsideup.jabel.Desugar;
+
+/**
+ * How a specific block state is placed by autoplace: what fluid it costs, and how to write it into the world.
+ * <p>
+ * Register one of these through {@link FluidPlacementRegistry} to teach StructureLib about a fluid block that it cannot
+ * figure out on its own, e.g. a fluid block that stores its fluid somewhere else, or one whose fluid cost is not the
+ * default bucket.
+ *
+ * @param cost       the fluid that has to be paid for one block of this state. Must hold a fluid and a positive amount.
+ * @param forceFluid whether to always pay with fluid, even when this block also has an item form. When false, the item
+ *                   form is preferred, which keeps the behaviour of existing multiblocks unchanged.
+ * @param placer     how to actually place the block, or null to place it with a plain block set
+ */
+@Desugar
+public record FluidBlockPlacement(FluidStack cost, boolean forceFluid, @Nullable FluidBlockPlacer placer) {
+
+    public FluidBlockPlacement {
+        if (cost == null || cost.getFluid() == null) throw new IllegalArgumentException("cost must hold a fluid");
+        if (cost.amount <= 0) throw new IllegalArgumentException("cost must have a positive amount");
+    }
+
+    /**
+     * A placement that pays with given fluid, prefers the item form when there is one, and places the block directly.
+     */
+    public static FluidBlockPlacement of(FluidStack cost) {
+        return new FluidBlockPlacement(cost, false, null);
+    }
+
+    /**
+     * A placement that pays with given fluid, and always pays with fluid even when the block has an item form.
+     */
+    public static FluidBlockPlacement forced(FluidStack cost) {
+        return new FluidBlockPlacement(cost, true, null);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockPlacer.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockPlacer.java
@@ -1,0 +1,30 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * Put a fluid block into the world.
+ * <p>
+ * The default implementation used by StructureLib is a plain {@code world.setBlock(x, y, z, block, meta, 2)}, which is
+ * what every vanilla and Forge fluid block expects. Register a custom placer for a fluid block that needs more than
+ * that, e.g. one that keeps its fluid inside a tile entity.
+ */
+public interface FluidBlockPlacer {
+
+    /**
+     * Place the fluid block.
+     *
+     * @param world world to place in. Never a client side world.
+     * @param x     x coord
+     * @param y     y coord
+     * @param z     z coord
+     * @param block block to place
+     * @param meta  block meta to place
+     * @param fluid the fluid that has been paid for, and how much of it. Never null.
+     * @return true if the block has been placed, false otherwise. Autoplace rolls back and refunds nothing when this
+     *         returns false before anything was consumed.
+     */
+    boolean place(World world, int x, int y, int z, Block block, int meta, FluidStack fluid);
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockRequirement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidBlockRequirement.java
@@ -1,0 +1,55 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraftforge.fluids.FluidStack;
+
+import com.github.bsideup.jabel.Desugar;
+
+/**
+ * A concrete request to put one fluid block at one position: which block and meta the structure wants there, what that
+ * costs, and how strict the check for an already partially filled position is.
+ * <p>
+ * Structure elements create one of these, either from the {@link FluidPlacementRegistry} or from their own parameters,
+ * and hand it to the autoplace helper.
+ *
+ * @param block  the block the structure wants at that position
+ * @param meta   the block meta the structure wants at that position
+ * @param cost   the fluid that has to be paid for a position that holds nothing yet. Must hold a fluid and a positive
+ *               amount.
+ * @param policy how much fluid an existing position has to hold to be accepted as is
+ * @param placer how to actually place the block, or null to place it with a plain block set
+ */
+@Desugar
+public record FluidBlockRequirement(Block block, int meta, FluidStack cost, FluidFillPolicy policy,
+        @Nullable FluidBlockPlacer placer) {
+
+    public FluidBlockRequirement {
+        if (block == null) throw new IllegalArgumentException("block must not be null");
+        if (cost == null || cost.getFluid() == null) throw new IllegalArgumentException("cost must hold a fluid");
+        if (cost.amount <= 0) throw new IllegalArgumentException("cost must have a positive amount");
+        if (policy == null) throw new IllegalArgumentException("policy must not be null");
+    }
+
+    /**
+     * Build a requirement from a registered placement.
+     *
+     * @param placement what the registry knows about this block state
+     * @param block     the block the structure wants
+     * @param meta      the block meta the structure wants
+     * @param policy    how strict the check for an already partially filled position is
+     */
+    public static FluidBlockRequirement of(FluidBlockPlacement placement, Block block, int meta,
+            FluidFillPolicy policy) {
+        if (placement == null) throw new IllegalArgumentException("placement must not be null");
+        return new FluidBlockRequirement(block, meta, placement.cost(), policy, placement.placer());
+    }
+
+    /**
+     * Build a requirement that pays with given fluid, and that places the block directly.
+     */
+    public static FluidBlockRequirement of(Block block, int meta, FluidStack cost, FluidFillPolicy policy) {
+        return new FluidBlockRequirement(block, meta, cost, policy, null);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidContainerExtractor.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidContainerExtractor.java
@@ -1,0 +1,78 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * Extract fluid from a single item stack, e.g. a bucket or a cell.
+ * <p>
+ * Implementations are registered in {@link FluidContainerExtractors}. StructureLib ships implementations for Forge's
+ * {@code IFluidContainerItem} and for {@code FluidContainerRegistry}, which together cover the vast majority of fluid
+ * containers. Register your own implementation when your containers expose their fluid by other means, e.g. fluid
+ * stored inside a backpack or inside a custom NBT layout.
+ * <p>
+ * All methods must be side effect free when a simulation is requested, and must never depend on a world.
+ */
+public interface FluidContainerExtractor {
+
+    /**
+     * Whether this extractor can work with given item stack. This must be a cheap, side effect free check.
+     *
+     * @param stack the stack to test. never null.
+     */
+    boolean isValidSource(ItemStack stack);
+
+    /**
+     * Extract up to {@code resource.amount} of fluid from this container.
+     * <p>
+     * The container item itself is never swapped by this method. A container whose fluid is stored in its NBT may
+     * mutate that NBT in place when {@code simulate} is false. A container that has to turn into another item, or to
+     * disappear, declares so through {@link #convertsContainer(ItemStack, FluidStack)} and
+     * {@link #getReplacement(ItemStack)} instead.
+     * <p>
+     * A container that is consumed as a whole, i.e. one that answers true from
+     * {@link #convertsContainer(ItemStack, FluidStack)}, cannot be split, so it may report the whole content of the
+     * container even when that is more than was asked for. Such a surplus is spent, as a half emptied bucket does not
+     * exist.
+     *
+     * @param container what to drain from. never null, and always accepted by {@link #isValidSource(ItemStack)}.
+     * @param resource  the fluid to drain, and how much of it at most. never null, and never mutated.
+     * @param simulate  whether to actually commit the modification. true for dry run, false otherwise.
+     * @return amount of fluid drained. never negative, and never more than {@code resource.amount} unless this
+     *         container is consumed as a whole
+     */
+    int drain(ItemStack container, FluidStack resource, boolean simulate);
+
+    /**
+     * Whether draining this container would turn it into another item, or make it disappear.
+     * <p>
+     * Called before draining, with the container still holding its fluid. When this returns true, the caller replaces
+     * the whole slot with {@link #getReplacement(ItemStack)} after a successful drain, so the implementation is
+     * responsible for the whole stack: either it has to be a container that is drained as a unit, e.g. a bucket, or
+     * {@link #drain(ItemStack, FluidStack, boolean)} has to reduce {@code stackSize} itself, as a stack of fluid drops
+     * does.
+     *
+     * @param container the container stack, in its state before being drained
+     * @param resource  the fluid that is about to be drained, and how much of it at most
+     */
+    default boolean convertsContainer(ItemStack container, FluidStack resource) {
+        return false;
+    }
+
+    /**
+     * The item stack that should replace given container once it got drained, or null when the container slot should
+     * become empty instead.
+     * <p>
+     * The caller refuses to drain a container that has to be replaced by another item while its slot holds more than
+     * one item, as it cannot hand the replacement back to the player safely. A null replacement is always allowed, as
+     * it only empties the slot.
+     *
+     * @param container the container stack, in its state before being drained
+     */
+    @Nullable
+    default ItemStack getReplacement(ItemStack container) {
+        return null;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidContainerExtractors.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidContainerExtractors.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizon.structurelib.fluid;
 
+import java.util.Iterator;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -11,6 +13,10 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
 import com.gtnewhorizon.structurelib.SortedRegistry;
+import com.gtnewhorizon.structurelib.util.InventoryIterable;
+import com.gtnewhorizon.structurelib.util.InventoryUtility;
+import com.gtnewhorizon.structurelib.util.InventoryUtility.InventoryProvider;
+import com.gtnewhorizon.structurelib.util.InventoryUtility.ItemStackExtractor;
 
 /**
  * The registry of every way StructureLib knows how to pull fluid out of an item, plus the inventory walk that uses
@@ -49,11 +55,16 @@ public class FluidContainerExtractors {
     }
 
     /**
-     * Extract fluid from the main inventory of given player.
+     * Extract fluid from every inventory associated with the given player.
      * <p>
-     * Armor slots are excluded. Containers nested inside another item, e.g. inside a backpack, are not looked into. A
-     * mod that wants to support those can register its own extractor, or hand its own fluid source to autoplace through
-     * its autoplace environment.
+     * This walks exactly the same inventories as item autoplace does, see
+     * {@link com.gtnewhorizon.structurelib.util.InventoryUtility}: the main inventory first, then whatever else is
+     * registered, which currently means the ender chest when a mod asked for it and every inventory a mod registered
+     * for a backpack. Inside every item that holds an inventory the walk goes one level deep, so a bucket a player left
+     * in a backpack is found, and a mod that already lets autoplace take items out of its backpacks does not have to do
+     * anything for the fluid containers inside them.
+     * <p>
+     * Armor slots are excluded, as there is no fluid container that goes into one.
      *
      * @param player   where to take fluid from
      * @param resource what fluid to take, and how much of it at most
@@ -61,22 +72,49 @@ public class FluidContainerExtractors {
      * @return what has actually been taken. Never null, and never holding more than requested.
      */
     public static FluidStack takeFromPlayer(EntityPlayerMP player, FluidStack resource, boolean simulate) {
-        // Only the main inventory, as there is no fluid container that goes into an armor slot.
-        FluidStack taken = takeFromInventory(
-                player.inventory,
-                resource,
-                simulate,
-                player,
-                player.inventory.mainInventory.length);
-        // A fake player, e.g. one a structure preview tool uses, has no connection to sync the inventory over.
-        if (!simulate && taken.amount > 0 && player.playerNetServerHandler != null) {
-            player.inventoryContainer.detectAndSendChanges();
+        if (player == null) throw new IllegalArgumentException();
+        if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+        int remaining = resource.amount;
+        for (InventoryProvider<?> provider : InventoryUtility.getInventoryProviders(player)) {
+            if (remaining <= 0) break;
+            remaining -= takeFromProvider(player, provider, new FluidStack(resource, remaining), simulate);
         }
+        return new FluidStack(resource, resource.amount - remaining);
+    }
+
+    /**
+     * Extract fluid from one registered inventory of a player, and let its provider know it changed.
+     * <p>
+     * The wildcard of {@link InventoryProvider} is captured by this method's type parameter, which is what allows the
+     * inventory to be handed back to {@code markDirty}.
+     */
+    private static <R extends Iterable<ItemStack>> int takeFromProvider(EntityPlayerMP player,
+            InventoryProvider<R> provider, FluidStack resource, boolean simulate) {
+        R inventory = provider.getInventory(player);
+        if (inventory == null) return 0;
+        // Only an inventory that is backed by an IInventory can have a slot written back, which a container such as a
+        // bucket needs when it is emptied into the world. A provider that hands out its stacks some other way is
+        // skipped rather than drained in place, as draining without replacing would leave the player a filled
+        // container that is already spent.
+        if (!(inventory instanceof InventoryIterable<?>iterable)) return 0;
+        int taken = takeFromInventory(iterable.getInventory(), resource, simulate, player, iterable.getMaxSlot(), true);
+        if (taken > 0 && !simulate && hasConnection(player)) provider.markDirty(inventory);
         return taken;
     }
 
     /**
+     * Whether the inventory of given player has a client to be kept in sync with. A fake player, e.g. the one a
+     * structure preview tool uses, has no connection, and an inventory it changed never has to be sent anywhere.
+     */
+    private static boolean hasConnection(EntityPlayerMP player) {
+        return player.playerNetServerHandler != null;
+    }
+
+    /**
      * Extract fluid from given inventory.
+     * <p>
+     * Containers held inside an item of this inventory, e.g. in a backpack, are not looked into here. Take from a
+     * player through {@link #takeFromPlayer(EntityPlayerMP, FluidStack, boolean)} to look into those as well.
      *
      * @param inv      where to take fluid from
      * @param resource what fluid to take, and how much of it at most
@@ -84,38 +122,94 @@ public class FluidContainerExtractors {
      * @return what has actually been taken. Never null, and never holding more than requested.
      */
     public static FluidStack takeFromInventory(IInventory inv, FluidStack resource, boolean simulate) {
-        return takeFromInventory(inv, resource, simulate, null, -1);
-    }
-
-    private static FluidStack takeFromInventory(IInventory inv, FluidStack resource, boolean simulate,
-            @Nullable EntityPlayerMP player, int maxSlot) {
         if (inv == null) throw new IllegalArgumentException();
         if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+        return new FluidStack(resource, takeFromInventory(inv, resource, simulate, null, -1, false));
+    }
+
+    /**
+     * Walk the slots of one inventory and take as much of the requested fluid as they hold.
+     *
+     * @param maxSlot   slot to stop at, exclusive. -1 for every slot
+     * @param recursive whether to look inside the items of this inventory, e.g. into a backpack
+     * @return how much has been taken, never more than requested
+     */
+    private static int takeFromInventory(IInventory inv, FluidStack resource, boolean simulate,
+            @Nullable EntityPlayerMP player, int maxSlot, boolean recursive) {
         int slots = maxSlot < 0 ? inv.getSizeInventory() : Math.min(maxSlot, inv.getSizeInventory());
         int remaining = resource.amount;
         for (int slot = 0; slot < slots && remaining > 0; slot++) {
             ItemStack stack = inv.getStackInSlot(slot);
             if (stack == null || stack.getItem() == null || stack.stackSize <= 0) continue;
-            for (FluidContainerExtractor extractor : EXTRACTORS.getPlayerOrdering(player)) {
-                if (!extractor.isValidSource(stack)) continue;
-                FluidStack request = new FluidStack(resource, remaining);
-                boolean converts = extractor.convertsContainer(stack, request);
-                ItemStack replacement = converts ? extractor.getReplacement(stack) : null;
-                // A container that turns into another item can only be replaced when it is the only item in its slot.
-                if (replacement != null && stack.stackSize != 1) continue;
-                int drained = extractor.drain(stack, request, simulate);
-                if (drained <= 0) continue;
-                remaining -= Math.min(remaining, drained);
-                if (!simulate && converts) {
-                    // A null replacement means the whole slot is spent, e.g. the drops of a fluid that was paid in
-                    // full.
-                    inv.setInventorySlotContents(slot, replacement);
-                    inv.markDirty();
-                }
-                break;
+            int taken = takeFromStack(stack, inv, slot, resource, remaining, simulate, player);
+            if (taken > 0) {
+                remaining -= taken;
+                continue;
+            }
+            if (recursive && player != null) {
+                remaining -= takeFromNested(player, stack, new FluidStack(resource, remaining), simulate);
             }
         }
-        return new FluidStack(resource, resource.amount - remaining);
+        return resource.amount - remaining;
+    }
+
+    /**
+     * Take fluid out of a single slot, using the first extractor that recognises what is in it.
+     *
+     * @return how much has been taken out of this slot, never more than requested
+     */
+    private static int takeFromStack(ItemStack stack, IInventory owner, int slot, FluidStack resource, int maxAmount,
+            boolean simulate, @Nullable EntityPlayerMP player) {
+        for (FluidContainerExtractor extractor : EXTRACTORS.getPlayerOrdering(player)) {
+            if (!extractor.isValidSource(stack)) continue;
+            FluidStack request = new FluidStack(resource, maxAmount);
+            boolean converts = extractor.convertsContainer(stack, request);
+            ItemStack replacement = converts ? extractor.getReplacement(stack) : null;
+            // A container that turns into another item can only be replaced when it is the only item in its slot.
+            if (replacement != null && stack.stackSize != 1) continue;
+            int drained = extractor.drain(stack, request, simulate);
+            if (drained <= 0) continue;
+            if (!simulate && converts) {
+                // A null replacement means the whole slot is spent, e.g. the drops of a fluid that was paid in full.
+                owner.setInventorySlotContents(slot, replacement);
+                owner.markDirty();
+            }
+            return Math.min(drained, maxAmount);
+        }
+        return 0;
+    }
+
+    /**
+     * Look inside the given stack for an inventory, e.g. a backpack, and take fluid out of the containers it holds.
+     * <p>
+     * Which stacks hold an inventory is decided by {@link InventoryUtility}, which is the same registry item autoplace
+     * uses, so a mod that already lets autoplace take items out of its backpacks gets the fluid containers inside them
+     * for free and never has to register anything for fluid. Only one level is looked into, exactly like the item walk
+     * does.
+     *
+     * @return how much has been taken, never more than requested
+     */
+    private static int takeFromNested(EntityPlayerMP player, ItemStack stack, FluidStack resource, boolean simulate) {
+        int taken = 0;
+        for (Iterator<? extends ItemStackExtractor> iter = InventoryUtility.getStackExtractors(player); iter
+                .hasNext();) {
+            ItemStackExtractor extractor = iter.next();
+            if (!extractor.isValidSource(stack, player)) continue;
+            IInventory nested = extractor.getInventory(stack, player);
+            if (nested == null) continue;
+            int fromNested = takeFromInventory(
+                    nested,
+                    new FluidStack(resource, resource.amount - taken),
+                    simulate,
+                    player,
+                    -1,
+                    false);
+            if (fromNested <= 0) continue;
+            if (!simulate) nested.markDirty();
+            taken += fromNested;
+            break;
+        }
+        return taken;
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidContainerExtractors.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidContainerExtractors.java
@@ -1,0 +1,192 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidContainerRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidContainerItem;
+
+import com.gtnewhorizon.structurelib.SortedRegistry;
+
+/**
+ * The registry of every way StructureLib knows how to pull fluid out of an item, plus the inventory walk that uses
+ * these extractors.
+ * <p>
+ * This is the fluid counterpart of the item extraction facilities that survival autoplace already relies on, including
+ * the fact that the registry is a {@link SortedRegistry}: entries can be reordered or disabled by the player in
+ * StructureLib's config, and the ordering can be synced to the server.
+ */
+public class FluidContainerExtractors {
+
+    private static final SortedRegistry<FluidContainerExtractor> EXTRACTORS = new SortedRegistry<>(
+            "fluidcontainerextractors");
+
+    static {
+        register("3000-forge-fluid-container-item", new ForgeFluidContainerItemExtractor());
+        register("5000-forge-fluid-container-registry", new ForgeFluidContainerRegistryExtractor());
+    }
+
+    private FluidContainerExtractors() {}
+
+    /**
+     * Dummy method to force the class to initialize, and with it the builtin extractors.
+     */
+    public static void init() {}
+
+    /**
+     * Register an extractor. Lower keys are tried first, so a mod that wants its extractor to take priority over
+     * StructureLib builtin ones should use a key sorting before {@code "3000-forge-fluid-container-item"}.
+     *
+     * @param key unique key. Matches the key shown in the config gui.
+     * @param val the extractor
+     */
+    public static void register(String key, FluidContainerExtractor val) {
+        EXTRACTORS.register(key, val);
+    }
+
+    /**
+     * Extract fluid from the main inventory of given player.
+     * <p>
+     * Armor slots are excluded. Containers nested inside another item, e.g. inside a backpack, are not looked into. A
+     * mod that wants to support those can register its own extractor, or hand its own fluid source to autoplace through
+     * its autoplace environment.
+     *
+     * @param player   where to take fluid from
+     * @param resource what fluid to take, and how much of it at most
+     * @param simulate whether to actually take the fluid
+     * @return what has actually been taken. Never null, and never holding more than requested.
+     */
+    public static FluidStack takeFromPlayer(EntityPlayerMP player, FluidStack resource, boolean simulate) {
+        // Only the main inventory, as there is no fluid container that goes into an armor slot.
+        FluidStack taken = takeFromInventory(
+                player.inventory,
+                resource,
+                simulate,
+                player,
+                player.inventory.mainInventory.length);
+        // A fake player, e.g. one a structure preview tool uses, has no connection to sync the inventory over.
+        if (!simulate && taken.amount > 0 && player.playerNetServerHandler != null) {
+            player.inventoryContainer.detectAndSendChanges();
+        }
+        return taken;
+    }
+
+    /**
+     * Extract fluid from given inventory.
+     *
+     * @param inv      where to take fluid from
+     * @param resource what fluid to take, and how much of it at most
+     * @param simulate whether to actually take the fluid
+     * @return what has actually been taken. Never null, and never holding more than requested.
+     */
+    public static FluidStack takeFromInventory(IInventory inv, FluidStack resource, boolean simulate) {
+        return takeFromInventory(inv, resource, simulate, null, -1);
+    }
+
+    private static FluidStack takeFromInventory(IInventory inv, FluidStack resource, boolean simulate,
+            @Nullable EntityPlayerMP player, int maxSlot) {
+        if (inv == null) throw new IllegalArgumentException();
+        if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+        int slots = maxSlot < 0 ? inv.getSizeInventory() : Math.min(maxSlot, inv.getSizeInventory());
+        int remaining = resource.amount;
+        for (int slot = 0; slot < slots && remaining > 0; slot++) {
+            ItemStack stack = inv.getStackInSlot(slot);
+            if (stack == null || stack.getItem() == null || stack.stackSize <= 0) continue;
+            for (FluidContainerExtractor extractor : EXTRACTORS.getPlayerOrdering(player)) {
+                if (!extractor.isValidSource(stack)) continue;
+                FluidStack request = new FluidStack(resource, remaining);
+                boolean converts = extractor.convertsContainer(stack, request);
+                ItemStack replacement = converts ? extractor.getReplacement(stack) : null;
+                // A container that turns into another item can only be replaced when it is the only item in its slot.
+                if (replacement != null && stack.stackSize != 1) continue;
+                int drained = extractor.drain(stack, request, simulate);
+                if (drained <= 0) continue;
+                remaining -= Math.min(remaining, drained);
+                if (!simulate && converts) {
+                    // A null replacement means the whole slot is spent, e.g. the drops of a fluid that was paid in
+                    // full.
+                    inv.setInventorySlotContents(slot, replacement);
+                    inv.markDirty();
+                }
+                break;
+            }
+        }
+        return new FluidStack(resource, resource.amount - remaining);
+    }
+
+    /**
+     * Builtin extractor for containers implementing Forge's {@code IFluidContainerItem}, e.g. cells. Such containers
+     * keep their own fluid inside their NBT, so they are drained in place, and only turn into another item when their
+     * item declares a container item.
+     */
+    public static class ForgeFluidContainerItemExtractor implements FluidContainerExtractor {
+
+        @Override
+        public boolean isValidSource(ItemStack stack) {
+            return stack != null && stack.getItem() instanceof IFluidContainerItem;
+        }
+
+        @Override
+        public int drain(ItemStack container, FluidStack resource, boolean simulate) {
+            IFluidContainerItem item = (IFluidContainerItem) container.getItem();
+            FluidStack contained = item.getFluid(container);
+            if (contained == null || !contained.isFluidEqual(resource)) return 0;
+            FluidStack drained = item.drain(container, Math.min(contained.amount, resource.amount), !simulate);
+            return drained == null ? 0 : Math.min(drained.amount, resource.amount);
+        }
+
+        @Override
+        public boolean convertsContainer(ItemStack container, FluidStack resource) {
+            Item item = container.getItem();
+            if (item == null || !item.hasContainerItem(container)) return false;
+            FluidStack contained = ((IFluidContainerItem) item).getFluid(container);
+            // The container only turns into another item when this drain empties it for good.
+            return contained != null && contained.amount <= resource.amount;
+        }
+
+        @Nullable
+        @Override
+        public ItemStack getReplacement(ItemStack container) {
+            Item item = container.getItem();
+            return item == null ? null : item.getContainerItem(container);
+        }
+    }
+
+    /**
+     * Builtin extractor for containers registered with Forge's {@code FluidContainerRegistry}, e.g. buckets. Such
+     * containers are consumed as a whole, and are replaced by their container item.
+     */
+    public static class ForgeFluidContainerRegistryExtractor implements FluidContainerExtractor {
+
+        @Override
+        public boolean isValidSource(ItemStack stack) {
+            return stack != null && stack.getItem() != null && FluidContainerRegistry.isFilledContainer(stack);
+        }
+
+        @Override
+        public int drain(ItemStack container, FluidStack resource, boolean simulate) {
+            if (container.stackSize != 1) return 0;
+            FluidStack contained = FluidContainerRegistry.getFluidForFilledItem(container);
+            if (contained == null || !contained.isFluidEqual(resource)) return 0;
+            // A bucket cannot be half emptied. Report the whole bucket, even when only part of it is needed.
+            return contained.amount;
+        }
+
+        @Override
+        public boolean convertsContainer(ItemStack container, FluidStack resource) {
+            return container.stackSize == 1;
+        }
+
+        @Nullable
+        @Override
+        public ItemStack getReplacement(ItemStack container) {
+            Item item = container.getItem();
+            if (item != null && item.hasContainerItem(container)) return item.getContainerItem(container);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidFillPolicy.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidFillPolicy.java
@@ -1,0 +1,43 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+/**
+ * How much fluid a position has to hold before a fluid structure element considers it satisfied.
+ * <p>
+ * Structure definitions pick a policy, which allows a structure to accept an already partially filled position, e.g.
+ * one that got filled by fluid that spread from somewhere else, instead of insisting on a full source block.
+ */
+public enum FluidFillPolicy {
+
+    /**
+     * The position has to hold exactly the amount of fluid the structure element asks for. This is the default, and it
+     * accepts a full source block while rejecting anything that holds less.
+     */
+    EXACT_STATE,
+    /**
+     * The position has to hold at least the amount of fluid the structure element asks for. A position holding more
+     * fluid than asked for is accepted as is, and is never drained down by autoplace.
+     */
+    AT_LEAST,
+    /**
+     * The position has to hold any amount of the same fluid at all. Only a position that holds no fluid of that kind is
+     * topped up.
+     */
+    ANY_FILLED;
+
+    /**
+     * Test whether the given amount is acceptable.
+     *
+     * @param existingAmount how much fluid the position holds right now
+     * @param targetAmount   how much fluid the structure element asks for
+     */
+    public boolean isSatisfied(int existingAmount, int targetAmount) {
+        switch (this) {
+            case EXACT_STATE:
+                return existingAmount == targetAmount;
+            case AT_LEAST:
+                return existingAmount >= targetAmount;
+            default:
+                return existingAmount > 0;
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidPlacementRegistry.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidPlacementRegistry.java
@@ -1,0 +1,196 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidBlock;
+import net.minecraftforge.oredict.OreDictionary;
+
+/**
+ * Tells StructureLib what it costs to place a fluid block, and how to place it.
+ * <p>
+ * A structure element that wants a fluid block, e.g. one created by {@code StructureUtility.ofBlock(Block, int)}, asks
+ * this registry what the block state costs. Water and lava are registered by default, every other Forge fluid block is
+ * recognised automatically with {@link #DEFAULT_FLUID_AMOUNT} per block, and a mod can register its own fluids, its own
+ * costs, and its own placement logic here.
+ * <p>
+ * Registrations are keyed by block and block meta. Registering the wildcard meta {@link OreDictionary#WILDCARD_VALUE}
+ * covers every meta of that block that does not have its own registration.
+ */
+public class FluidPlacementRegistry {
+
+    /**
+     * How much fluid one block of an automatically recognised fluid costs, which is one bucket by default.
+     */
+    public static final int DEFAULT_FLUID_AMOUNT = 1000;
+
+    private static final Map<Block, Map<Integer, FluidBlockPlacement>> REGISTRY = new ConcurrentHashMap<>();
+    /**
+     * Block to fluid index, so that looking up a block that turns out not to be a fluid doesn't have to walk every
+     * registered fluid. Rebuilt whenever the fluid registry grows, e.g. when a mod registers its fluids later than the
+     * first lookup.
+     */
+    private static final Map<Block, Fluid> FLUID_BLOCKS = new ConcurrentHashMap<>();
+    private static volatile int indexedFluidCount = -1;
+
+    static {
+        register(Blocks.water, 0, FluidBlockPlacement.of(new FluidStack(FluidRegistry.WATER, DEFAULT_FLUID_AMOUNT)));
+        register(
+                Blocks.flowing_water,
+                0,
+                FluidBlockPlacement.of(new FluidStack(FluidRegistry.WATER, DEFAULT_FLUID_AMOUNT)));
+        register(Blocks.lava, 0, FluidBlockPlacement.of(new FluidStack(FluidRegistry.LAVA, DEFAULT_FLUID_AMOUNT)));
+        register(
+                Blocks.flowing_lava,
+                0,
+                FluidBlockPlacement.of(new FluidStack(FluidRegistry.LAVA, DEFAULT_FLUID_AMOUNT)));
+    }
+
+    private FluidPlacementRegistry() {}
+
+    /**
+     * Dummy method to force the class to initialize, and with it the default water and lava registrations.
+     */
+    public static void init() {}
+
+    /**
+     * Register what it costs to place the given block state, preferring the item form when the block has one.
+     *
+     * @param block the fluid block
+     * @param meta  the block meta. {@link OreDictionary#WILDCARD_VALUE} covers every meta of this block.
+     * @param cost  how much fluid one block of this state costs
+     * @throws IllegalArgumentException if the block is null, the cost is invalid, or this state is already registered
+     */
+    public static void register(Block block, int meta, FluidStack cost) {
+        register(block, meta, FluidBlockPlacement.of(cost));
+    }
+
+    /**
+     * Register what it costs to place the given block state.
+     *
+     * @param block      the fluid block
+     * @param meta       the block meta. {@link OreDictionary#WILDCARD_VALUE} covers every meta of this block.
+     * @param forceFluid whether to always pay with fluid, even when this block also has an item form
+     * @param cost       how much fluid one block of this state costs
+     * @throws IllegalArgumentException if the block is null, the cost is invalid, or this state is already registered
+     */
+    public static void register(Block block, int meta, FluidStack cost, boolean forceFluid) {
+        register(block, meta, new FluidBlockPlacement(cost, forceFluid, null));
+    }
+
+    /**
+     * Register what it costs to place the given block state, and how to place it.
+     *
+     * @param block     the fluid block
+     * @param meta      the block meta. {@link OreDictionary#WILDCARD_VALUE} covers every meta of this block.
+     * @param placement the cost and the placement logic
+     * @throws IllegalArgumentException if the block or the placement is null, or this state is already registered
+     */
+    public static void register(Block block, int meta, FluidBlockPlacement placement) {
+        if (block == null) throw new IllegalArgumentException("block must not be null");
+        if (placement == null) throw new IllegalArgumentException("placement must not be null");
+        Map<Integer, FluidBlockPlacement> byMeta = REGISTRY.computeIfAbsent(block, b -> new ConcurrentHashMap<>());
+        if (byMeta.putIfAbsent(meta, placement) != null) {
+            throw new IllegalArgumentException(
+                    "Duplicate fluid placement for " + block.getUnlocalizedName() + ":" + meta);
+        }
+    }
+
+    /**
+     * What has been registered for exactly this block state.
+     *
+     * @return the registration, or null when there is none
+     */
+    @Nullable
+    public static FluidBlockPlacement get(Block block, int meta) {
+        if (block == null) return null;
+        Map<Integer, FluidBlockPlacement> byMeta = REGISTRY.get(block);
+        if (byMeta == null) return null;
+        FluidBlockPlacement placement = byMeta.get(meta);
+        return placement != null ? placement : byMeta.get(OreDictionary.WILDCARD_VALUE);
+    }
+
+    /**
+     * What it costs to place this block state, whether it has been registered or not.
+     * <p>
+     * This is what autoplace asks. A registered state answers with its registration. Otherwise a block implementing
+     * Forge's {@code IFluidBlock}, and any block whose material is a liquid, answer with {@link #DEFAULT_FLUID_AMOUNT}
+     * of the fluid they hold, scaled down for a meta that asks for a partial block.
+     *
+     * @return the placement, or null when this block state is not a fluid block
+     */
+    @Nullable
+    public static FluidBlockPlacement resolve(Block block, int meta) {
+        FluidBlockPlacement placement = get(block, meta);
+        if (placement != null) return placement;
+        Fluid fluid = getFluidOf(block);
+        if (fluid == null) return null;
+        int amount = FluidAmounts.getAmountForMeta(block, meta, DEFAULT_FLUID_AMOUNT);
+        if (amount <= 0) return null;
+        return FluidBlockPlacement.of(new FluidStack(fluid, amount));
+    }
+
+    /**
+     * Whether this block state is a fluid block that autoplace can place.
+     */
+    public static boolean isFluidBlock(Block block, int meta) {
+        return resolve(block, meta) != null;
+    }
+
+    /**
+     * Whether this block state can be placed as an item, i.e. whether the block has an item form.
+     * <p>
+     * Autoplace prefers the item form when there is one, so that blocks that are both a fluid block and an item keep
+     * behaving the way they did before fluid autoplace existed.
+     */
+    public static boolean hasItemForm(Block block) {
+        if (block == null) return false;
+        return Item.getItemFromBlock(block) != null;
+    }
+
+    /**
+     * The fluid held by given block, if any.
+     * <p>
+     * A block implementing Forge's {@code IFluidBlock} answers directly. Everything else is looked up in an index of
+     * every registered fluid, and finally by material, which covers the vanilla water and lava blocks that no fluid
+     * claims.
+     *
+     * @return the fluid, or null when this block does not hold one
+     */
+    @Nullable
+    public static Fluid getFluidOf(Block block) {
+        if (block == null) return null;
+        if (block instanceof IFluidBlock fluidBlock) {
+            Fluid fluid = fluidBlock.getFluid();
+            if (fluid != null) return fluid;
+        }
+        Fluid byBlock = indexFluidBlocks().get(block);
+        if (byBlock != null) return byBlock;
+        Material material = block.getMaterial();
+        if (material == Material.water) return FluidRegistry.WATER;
+        if (material == Material.lava) return FluidRegistry.LAVA;
+        return null;
+    }
+
+    private static synchronized Map<Block, Fluid> indexFluidBlocks() {
+        Map<String, Fluid> fluids = FluidRegistry.getRegisteredFluids();
+        if (fluids.size() == indexedFluidCount) return FLUID_BLOCKS;
+        FLUID_BLOCKS.clear();
+        for (Fluid fluid : fluids.values()) {
+            if (fluid == null) continue;
+            Block block = fluid.getBlock();
+            if (block != null) FLUID_BLOCKS.put(block, fluid);
+        }
+        indexedFluidCount = fluids.size();
+        return FLUID_BLOCKS;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidPlacementRegistry.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidPlacementRegistry.java
@@ -43,16 +43,10 @@ public class FluidPlacementRegistry {
     private static volatile int indexedFluidCount = -1;
 
     static {
-        register(Blocks.water, 0, FluidBlockPlacement.of(new FluidStack(FluidRegistry.WATER, DEFAULT_FLUID_AMOUNT)));
-        register(
-                Blocks.flowing_water,
-                0,
-                FluidBlockPlacement.of(new FluidStack(FluidRegistry.WATER, DEFAULT_FLUID_AMOUNT)));
-        register(Blocks.lava, 0, FluidBlockPlacement.of(new FluidStack(FluidRegistry.LAVA, DEFAULT_FLUID_AMOUNT)));
-        register(
-                Blocks.flowing_lava,
-                0,
-                FluidBlockPlacement.of(new FluidStack(FluidRegistry.LAVA, DEFAULT_FLUID_AMOUNT)));
+        register(Blocks.water, 0);
+        register(Blocks.flowing_water, 0);
+        register(Blocks.lava, 0);
+        register(Blocks.flowing_lava, 0);
     }
 
     private FluidPlacementRegistry() {}
@@ -72,6 +66,63 @@ public class FluidPlacementRegistry {
      */
     public static void register(Block block, int meta, FluidStack cost) {
         register(block, meta, FluidBlockPlacement.of(cost));
+    }
+
+    /**
+     * Register what it costs to place the given block state, with {@link #DEFAULT_FLUID_AMOUNT} of the fluid the block
+     * holds, preferring the item form when the block has one.
+     * <p>
+     * The amount is the whole cost of that state. A block whose meta says how full it is therefore wants one
+     * registration per meta it can be in, or no registration at all, in which case {@link #resolve(Block, int)} scales
+     * the default amount down for a partially filled block.
+     *
+     * @param block the fluid block
+     * @param meta  the block meta. {@link OreDictionary#WILDCARD_VALUE} covers every meta of this block.
+     * @throws IllegalArgumentException if the block holds no fluid, or this state is already registered
+     */
+    public static void register(Block block, int meta) {
+        register(block, meta, false);
+    }
+
+    /**
+     * Register what it costs to place the given block state, with {@link #DEFAULT_FLUID_AMOUNT} of the fluid the block
+     * holds.
+     *
+     * @param block      the fluid block
+     * @param meta       the block meta. {@link OreDictionary#WILDCARD_VALUE} covers every meta of this block.
+     * @param forceFluid whether to always pay with fluid, even when this block also has an item form
+     * @throws IllegalArgumentException if the block holds no fluid, or this state is already registered
+     */
+    public static void register(Block block, int meta, boolean forceFluid) {
+        FluidStack cost = FluidBlockPlacement.defaultCost(fluidOf(block));
+        register(block, meta, forceFluid ? FluidBlockPlacement.forced(cost) : FluidBlockPlacement.of(cost));
+    }
+
+    /**
+     * Register the whole block, i.e. every meta of it that has no registration of its own, with
+     * {@link #DEFAULT_FLUID_AMOUNT} of the fluid it holds.
+     *
+     * @param block the fluid block
+     * @throws IllegalArgumentException if the block holds no fluid, or the wildcard meta is already registered
+     */
+    public static void register(Block block) {
+        register(block, OreDictionary.WILDCARD_VALUE);
+    }
+
+    /**
+     * Register what it costs to place the given block state, with {@link #DEFAULT_FLUID_AMOUNT} of the fluid the block
+     * holds, and placed the way the given placer says.
+     * <p>
+     * Use this for a fluid block that cannot be placed with a plain block set, e.g. one that has to be filled through
+     * its own API.
+     *
+     * @param block  the fluid block
+     * @param meta   the block meta. {@link OreDictionary#WILDCARD_VALUE} covers every meta of this block.
+     * @param placer how to write the block into the world
+     * @throws IllegalArgumentException if the block holds no fluid, or this state is already registered
+     */
+    public static void register(Block block, int meta, FluidBlockPlacer placer) {
+        register(block, meta, FluidBlockPlacement.of(FluidBlockPlacement.defaultCost(fluidOf(block)), placer));
     }
 
     /**
@@ -179,6 +230,22 @@ public class FluidPlacementRegistry {
         if (material == Material.water) return FluidRegistry.WATER;
         if (material == Material.lava) return FluidRegistry.LAVA;
         return null;
+    }
+
+    /**
+     * The fluid held by given block, for the registrations that default to {@link #DEFAULT_FLUID_AMOUNT} of it.
+     *
+     * @throws IllegalArgumentException if the block is null or holds no fluid
+     */
+    private static Fluid fluidOf(Block block) {
+        Fluid fluid = getFluidOf(block);
+        if (fluid == null) {
+            throw new IllegalArgumentException(
+                    "Block " + (block == null ? "null" : block.getUnlocalizedName())
+                            + " holds no fluid,"
+                            + " register it with an explicit cost instead");
+        }
+        return fluid;
     }
 
     private static synchronized Map<Block, Fluid> indexFluidBlocks() {

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidSourceProviders.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidSourceProviders.java
@@ -1,0 +1,56 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import com.gtnewhorizon.structurelib.SortedRegistry;
+
+/**
+ * The registry of everything that can hand out fluid on a player's behalf, plus the composition that autoplace uses.
+ * <p>
+ * This mirrors {@link FluidContainerExtractors}: it is a {@link SortedRegistry}, so the player can reorder or disable
+ * every provider in StructureLib's config, and the ordering can be synced to the server. Providers are asked in order,
+ * and whatever the player is carrying comes last, so a provider that holds a lot of fluid, e.g. an ME network, is
+ * drained before the player's buckets are emptied.
+ */
+public class FluidSourceProviders {
+
+    private static final SortedRegistry<IFluidSourceProvider> PROVIDERS = new SortedRegistry<>("fluidsourceproviders");
+
+    private FluidSourceProviders() {}
+
+    /**
+     * Dummy method to force the class to initialize, and with it the registry and its config entry.
+     */
+    public static void init() {}
+
+    /**
+     * Register a provider. Lower keys are asked first.
+     *
+     * @param key      unique key. Matches the key shown in the config gui.
+     * @param provider the provider
+     */
+    public static void register(String key, IFluidSourceProvider provider) {
+        PROVIDERS.register(key, provider);
+    }
+
+    /**
+     * The fluid source to use for a player: every provider that has something to offer, in their configured order,
+     * followed by the fluid containers the player is carrying.
+     *
+     * @param player the player the structure is being built for
+     * @return a source that never returns more than it was asked for. never null.
+     */
+    public static IFluidSource getSourceFor(EntityPlayerMP player) {
+        if (player == null) throw new IllegalArgumentException();
+        List<IFluidSource> sources = new ArrayList<>();
+        for (IFluidSourceProvider provider : PROVIDERS.getPlayerOrdering(player)) {
+            IFluidSource source = provider.getFluidSource(player);
+            if (source != null) sources.add(source);
+        }
+        sources.add(IFluidSource.fromPlayer(player));
+        return IFluidSource.composite(sources.toArray(new IFluidSource[0]));
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidSourceProviders.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidSourceProviders.java
@@ -10,10 +10,10 @@ import com.gtnewhorizon.structurelib.SortedRegistry;
 /**
  * The registry of everything that can hand out fluid on a player's behalf, plus the composition that autoplace uses.
  * <p>
- * This mirrors {@link FluidContainerExtractors}: it is a {@link SortedRegistry}, so the player can reorder or disable
- * every provider in StructureLib's config, and the ordering can be synced to the server. Providers are asked in order,
- * and whatever the player is carrying comes last, so a provider that holds a lot of fluid, e.g. an ME network, is
- * drained before the player's buckets are emptied.
+ * This mirrors {@link FluidStackExtractors}: it is a {@link SortedRegistry}, so the player can reorder or disable every
+ * provider in StructureLib's config, and the ordering can be synced to the server. Providers are asked in order, and
+ * whatever the player is carrying comes last, so a provider that holds a lot of fluid, e.g. an ME network, is drained
+ * before the player's buckets are emptied.
  */
 public class FluidSourceProviders {
 

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidStackExtractor.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidStackExtractor.java
@@ -8,14 +8,14 @@ import net.minecraftforge.fluids.FluidStack;
 /**
  * Extract fluid from a single item stack, e.g. a bucket or a cell.
  * <p>
- * Implementations are registered in {@link FluidContainerExtractors}. StructureLib ships implementations for Forge's
+ * Implementations are registered in {@link FluidStackExtractors}. StructureLib ships implementations for Forge's
  * {@code IFluidContainerItem} and for {@code FluidContainerRegistry}, which together cover the vast majority of fluid
  * containers. Register your own implementation when your containers expose their fluid by other means, e.g. fluid
  * stored inside a backpack or inside a custom NBT layout.
  * <p>
  * All methods must be side effect free when a simulation is requested, and must never depend on a world.
  */
-public interface FluidContainerExtractor {
+public interface FluidStackExtractor {
 
     /**
      * Whether this extractor can work with given item stack. This must be a cheap, side effect free check.

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidStackExtractors.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/FluidStackExtractors.java
@@ -26,17 +26,16 @@ import com.gtnewhorizon.structurelib.util.InventoryUtility.ItemStackExtractor;
  * the fact that the registry is a {@link SortedRegistry}: entries can be reordered or disabled by the player in
  * StructureLib's config, and the ordering can be synced to the server.
  */
-public class FluidContainerExtractors {
+public class FluidStackExtractors {
 
-    private static final SortedRegistry<FluidContainerExtractor> EXTRACTORS = new SortedRegistry<>(
-            "fluidcontainerextractors");
+    private static final SortedRegistry<FluidStackExtractor> EXTRACTORS = new SortedRegistry<>("fluidstackextractors");
 
     static {
         register("3000-forge-fluid-container-item", new ForgeFluidContainerItemExtractor());
         register("5000-forge-fluid-container-registry", new ForgeFluidContainerRegistryExtractor());
     }
 
-    private FluidContainerExtractors() {}
+    private FluidStackExtractors() {}
 
     /**
      * Dummy method to force the class to initialize, and with it the builtin extractors.
@@ -50,7 +49,7 @@ public class FluidContainerExtractors {
      * @param key unique key. Matches the key shown in the config gui.
      * @param val the extractor
      */
-    public static void register(String key, FluidContainerExtractor val) {
+    public static void register(String key, FluidStackExtractor val) {
         EXTRACTORS.register(key, val);
     }
 
@@ -160,7 +159,7 @@ public class FluidContainerExtractors {
      */
     private static int takeFromStack(ItemStack stack, IInventory owner, int slot, FluidStack resource, int maxAmount,
             boolean simulate, @Nullable EntityPlayerMP player) {
-        for (FluidContainerExtractor extractor : EXTRACTORS.getPlayerOrdering(player)) {
+        for (FluidStackExtractor extractor : EXTRACTORS.getPlayerOrdering(player)) {
             if (!extractor.isValidSource(stack)) continue;
             FluidStack request = new FluidStack(resource, maxAmount);
             boolean converts = extractor.convertsContainer(stack, request);
@@ -217,7 +216,7 @@ public class FluidContainerExtractors {
      * keep their own fluid inside their NBT, so they are drained in place, and only turn into another item when their
      * item declares a container item.
      */
-    public static class ForgeFluidContainerItemExtractor implements FluidContainerExtractor {
+    public static class ForgeFluidContainerItemExtractor implements FluidStackExtractor {
 
         @Override
         public boolean isValidSource(ItemStack stack) {
@@ -254,7 +253,7 @@ public class FluidContainerExtractors {
      * Builtin extractor for containers registered with Forge's {@code FluidContainerRegistry}, e.g. buckets. Such
      * containers are consumed as a whole, and are replaced by their container item.
      */
-    public static class ForgeFluidContainerRegistryExtractor implements FluidContainerExtractor {
+    public static class ForgeFluidContainerRegistryExtractor implements FluidStackExtractor {
 
         @Override
         public boolean isValidSource(ItemStack stack) {

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/IFluidSource.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/IFluidSource.java
@@ -1,0 +1,149 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidHandler;
+
+/**
+ * Represent a source of fluid. Take only, cannot be put back. This is the fluid counterpart of the item source that
+ * survival autoplace already uses for blocks with an item form.
+ * <p>
+ * A structure element that has to place a fluid block asks the autoplace environment for a fluid source. When the
+ * environment doesn't carry one, StructureLib falls back to {@link #fromPlayer(EntityPlayerMP)} as long as the actor is
+ * a server side player, so multiblocks and third party tools that were written before this API existed keep working
+ * without any change.
+ * <p>
+ * Implementations are expected to be side effect free when {@code simulate} is true. A failed simulation followed by a
+ * successful one is not guaranteed to succeed, but it is not expected to happen either as autoplace runs on the server
+ * thread with no concurrent inventory modification.
+ */
+public interface IFluidSource {
+
+    /**
+     * Retrieve up to {@code resource.amount} of the given fluid from this source.
+     * <p>
+     * The given resource is never mutated.
+     *
+     * @param resource what fluid to extract, and how much of it at most. must have a positive amount.
+     * @param simulate whether to actually commit the modification. true for dry run, false otherwise.
+     * @return a new fluid stack describing what has actually been extracted. Never null. A zero amount means nothing
+     *         could be extracted. The returned stack keeps the NBT tag of the requested fluid.
+     * @throws IllegalArgumentException if the given resource is null or has no fluid
+     */
+    @Nonnull
+    FluidStack take(FluidStack resource, boolean simulate);
+
+    /**
+     * Take exactly {@code resource.amount} amount of fluid. Nothing is taken if the full amount isn't available.
+     *
+     * @param resource what fluid to extract, and how much of it. must have a positive amount.
+     * @param simulate whether to actually commit the modification. true for dry run, false otherwise.
+     * @return true if at least this much fluid can be/is taken.
+     * @throws IllegalArgumentException if the given resource is null or has no fluid
+     */
+    default boolean takeAll(FluidStack resource, boolean simulate) {
+        if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+        if (resource.amount <= 0) return true;
+        if (getAvailable(resource) < resource.amount) return false;
+        if (simulate) return true;
+        FluidStack taken = take(resource, false);
+        return taken != null && taken.amount >= resource.amount;
+    }
+
+    /**
+     * Query how much of the given fluid this source could provide right now.
+     *
+     * @param resource what fluid to query. must have a positive amount, which acts as the upper bound of the result.
+     * @return amount available, between 0 and {@code resource.amount} inclusive
+     * @throws IllegalArgumentException if the given resource is null or has no fluid
+     */
+    default int getAvailable(FluidStack resource) {
+        if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+        FluidStack taken = take(resource, true);
+        return taken == null ? 0 : Math.max(0, Math.min(taken.amount, resource.amount));
+    }
+
+    /**
+     * A source that never provides anything. Useful as a placeholder for a fluid source that is not available.
+     */
+    static IFluidSource empty() {
+        return (resource, simulate) -> {
+            if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+            return new FluidStack(resource, 0);
+        };
+    }
+
+    /**
+     * Combine several sources into one, asking them in order until the requested amount is met.
+     * <p>
+     * This is how a multiblock that wants its fluid to come from somewhere else than the player keeps the player's own
+     * containers as a fallback: {@code composite(custom, env.getEffectiveFluidSource())}.
+     *
+     * @param sources the sources to ask, in order. Null entries are skipped.
+     */
+    static IFluidSource composite(IFluidSource... sources) {
+        if (sources == null || sources.length == 0) return empty();
+        return (resource, simulate) -> {
+            if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+            int remaining = resource.amount;
+            for (IFluidSource source : sources) {
+                if (source == null || remaining <= 0) continue;
+                FluidStack taken = source.take(new FluidStack(resource, remaining), simulate);
+                if (taken == null || taken.amount <= 0) continue;
+                remaining -= Math.min(remaining, taken.amount);
+            }
+            return new FluidStack(resource, resource.amount - remaining);
+        };
+    }
+
+    /**
+     * Construct a fluid source from the fluid containers held by given player.
+     * <p>
+     * This will be backed by {@link FluidContainerExtractors}, which covers every fluid container registered with
+     * Forge, and every container type registered by another mod through
+     * {@link FluidContainerExtractors#register(String, FluidContainerExtractor)}.
+     */
+    static IFluidSource fromPlayer(EntityPlayerMP player) {
+        return (resource, simulate) -> FluidContainerExtractors.takeFromPlayer(player, resource, simulate);
+    }
+
+    /**
+     * Construct a fluid source from given inventory. Useful for multiblocks that want to drain fluid from a nearby
+     * machine instead of from the player.
+     * <p>
+     * This will be backed by {@link FluidContainerExtractors}.
+     */
+    static IFluidSource fromInventory(IInventory inv) {
+        return (resource, simulate) -> FluidContainerExtractors.takeFromInventory(inv, resource, simulate);
+    }
+
+    /**
+     * Construct a fluid source from a Forge fluid handler, e.g. a tank or a machine.
+     * <p>
+     * This is the intended way for a multiblock to pull fluid from a world container instead of from the player. A
+     * multiblock that wants to do so hands the source to autoplace through its own autoplace environment.
+     *
+     * @param handler the handler to drain from. must not be null.
+     * @param sides   sides to try, in order. An empty or null array means every side.
+     */
+    static IFluidSource fromHandler(IFluidHandler handler, ForgeDirection... sides) {
+        if (handler == null) throw new IllegalArgumentException();
+        ForgeDirection[] directions = sides == null || sides.length == 0 ? ForgeDirection.VALID_DIRECTIONS
+                : sides.clone();
+        return (resource, simulate) -> {
+            if (resource == null || resource.getFluid() == null) throw new IllegalArgumentException();
+            int remaining = resource.amount;
+            for (ForgeDirection direction : directions) {
+                if (remaining <= 0) break;
+                FluidStack drained = handler.drain(direction, new FluidStack(resource, remaining), !simulate);
+                if (drained == null || drained.getFluid() != resource.getFluid()) continue;
+                remaining -= Math.min(remaining, drained.amount);
+            }
+            return new FluidStack(resource, resource.amount - remaining);
+        };
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/IFluidSource.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/IFluidSource.java
@@ -103,22 +103,22 @@ public interface IFluidSource {
     /**
      * Construct a fluid source from the fluid containers held by given player.
      * <p>
-     * This will be backed by {@link FluidContainerExtractors}, which covers every fluid container registered with
-     * Forge, and every container type registered by another mod through
-     * {@link FluidContainerExtractors#register(String, FluidContainerExtractor)}.
+     * This will be backed by {@link FluidStackExtractors}, which covers every fluid container registered with Forge,
+     * and every container type registered by another mod through
+     * {@link FluidStackExtractors#register(String, FluidStackExtractor)}.
      */
     static IFluidSource fromPlayer(EntityPlayerMP player) {
-        return (resource, simulate) -> FluidContainerExtractors.takeFromPlayer(player, resource, simulate);
+        return (resource, simulate) -> FluidStackExtractors.takeFromPlayer(player, resource, simulate);
     }
 
     /**
      * Construct a fluid source from given inventory. Useful for multiblocks that want to drain fluid from a nearby
      * machine instead of from the player.
      * <p>
-     * This will be backed by {@link FluidContainerExtractors}.
+     * This will be backed by {@link FluidStackExtractors}.
      */
     static IFluidSource fromInventory(IInventory inv) {
-        return (resource, simulate) -> FluidContainerExtractors.takeFromInventory(inv, resource, simulate);
+        return (resource, simulate) -> FluidStackExtractors.takeFromInventory(inv, resource, simulate);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/fluid/IFluidSourceProvider.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/fluid/IFluidSourceProvider.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizon.structurelib.fluid;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * Offers a fluid source to ask before the fluid containers a player is carrying.
+ * <p>
+ * This is how a mod that can hand out fluid without an item in the player's inventory plugs into autoplace, e.g. the ME
+ * network behind a wireless fluid terminal the player has on them, or the tanks of a network the player has access to.
+ * Providers are registered in {@link FluidSourceProviders}, so the player can reorder or disable them in StructureLib's
+ * config like every other registered feature.
+ * <p>
+ * A provider is only ever asked for a server side player, and only while autoplace is placing a fluid block, so it does
+ * not have to be cheap, but it should still avoid work it can do lazily: the returned source is asked for fluid more
+ * than once, and should look up whatever it drains from at that point rather than when it is created.
+ */
+public interface IFluidSourceProvider {
+
+    /**
+     * A fluid source for the given player, or null when this provider has nothing to contribute right now.
+     *
+     * @param player the player the structure is being built for. never null, and never a client side player.
+     */
+    @Nullable
+    IFluidSource getFluidSource(EntityPlayerMP player);
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/AutoPlaceEnvironment.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/AutoPlaceEnvironment.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -12,6 +13,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IChatComponent;
 
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
+import com.gtnewhorizon.structurelib.fluid.IFluidSource;
 
 /**
  * Represent the environment in which autoplace of a single element took place.
@@ -19,6 +22,7 @@ import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 public class AutoPlaceEnvironment {
 
     private IItemSource source;
+    private IFluidSource fluidSource;
     private final EntityPlayer actor;
     private final Consumer<IChatComponent> chatter;
     private final IStructureDefinition<?> definition;
@@ -26,6 +30,9 @@ public class AutoPlaceEnvironment {
     private final ExtendedFacing facing;
     final int[] offsetABC;
     private final int[] baseOffsetABC;
+    private final int[] basePositionXYZ;
+    private final Object contextObject;
+    private final FluidRoundState fluidRoundState;
 
     public static AutoPlaceEnvironment fromLegacy(IItemSource source, EntityPlayer actor,
             Consumer<IChatComponent> chatter) {
@@ -41,12 +48,14 @@ public class AutoPlaceEnvironment {
             }
             return original;
         }
-        return new AutoPlaceEnvironment(source, actor, chatter, null, null, null, null, null);
+        return new AutoPlaceEnvironment(source, null, actor, chatter, null, null, null, null, null, null, null);
     }
 
     AutoPlaceEnvironment(EntityPlayer actor, Consumer<IChatComponent> chatter, IStructureDefinition<?> definition,
-            String piece, ExtendedFacing facing, int[] baseOffsetABC) {
+            String piece, ExtendedFacing facing, int[] baseOffsetABC, int[] basePositionXYZ, Object contextObject,
+            IFluidSource fluidSource, FluidRoundState fluidRoundState) {
         this.source = null;
+        this.fluidSource = fluidSource;
         this.actor = actor;
         this.chatter = chatter;
         this.definition = definition;
@@ -54,14 +63,37 @@ public class AutoPlaceEnvironment {
         this.facing = facing;
         this.offsetABC = new int[3];
         this.baseOffsetABC = baseOffsetABC;
+        this.basePositionXYZ = basePositionXYZ;
+        this.contextObject = contextObject;
+        this.fluidRoundState = fluidRoundState;
     }
 
-    AutoPlaceEnvironment(IItemSource source, EntityPlayer actor, Consumer<IChatComponent> chatter,
-            IStructureDefinition<?> definition, String piece, ExtendedFacing facing, int[] offsetABC,
-            int[] baseOffsetABC) {
+    AutoPlaceEnvironment(IItemSource source, IFluidSource fluidSource, EntityPlayer actor,
+            Consumer<IChatComponent> chatter, IStructureDefinition<?> definition, String piece, ExtendedFacing facing,
+            int[] offsetABC, int[] baseOffsetABC, int[] basePositionXYZ, Object contextObject) {
+        this(
+                source,
+                fluidSource,
+                actor,
+                chatter,
+                definition,
+                piece,
+                facing,
+                offsetABC,
+                baseOffsetABC,
+                basePositionXYZ,
+                contextObject,
+                null);
+    }
+
+    private AutoPlaceEnvironment(IItemSource source, IFluidSource fluidSource, EntityPlayer actor,
+            Consumer<IChatComponent> chatter, IStructureDefinition<?> definition, String piece, ExtendedFacing facing,
+            int[] offsetABC, int[] baseOffsetABC, int[] basePositionXYZ, Object contextObject,
+            FluidRoundState fluidRoundState) {
         this.source = definition != null && !(source instanceof WrappedIItemSource)
                 ? new WrappedIItemSource(this, source)
                 : source;
+        this.fluidSource = fluidSource;
         this.actor = actor;
         this.chatter = chatter;
         this.definition = definition;
@@ -69,18 +101,25 @@ public class AutoPlaceEnvironment {
         this.facing = facing;
         this.offsetABC = offsetABC;
         this.baseOffsetABC = baseOffsetABC;
+        this.basePositionXYZ = basePositionXYZ;
+        this.contextObject = contextObject;
+        this.fluidRoundState = fluidRoundState;
     }
 
     protected AutoPlaceEnvironment(AutoPlaceEnvironment parent) {
         this(
                 parent.getSource(),
+                parent.fluidSource,
                 parent.getActor(),
                 parent.getChatter(),
                 parent.definition,
                 parent.piece,
                 parent.facing,
                 parent.offsetABC,
-                parent.baseOffsetABC);
+                parent.baseOffsetABC,
+                parent.basePositionXYZ,
+                parent.contextObject,
+                parent.fluidRoundState);
     }
 
     void setSource(IItemSource source) {
@@ -99,6 +138,33 @@ public class AutoPlaceEnvironment {
      */
     public IItemSource getSource() {
         return source;
+    }
+
+    /**
+     * The fluid source this environment has been given, or null when it has none.
+     * <p>
+     * A structure element that has to place fluid blocks should ask {@link #getEffectiveFluidSource()} instead, which
+     * falls back to whatever the actor can offer when there is no explicit fluid source.
+     */
+    @Nullable
+    public IFluidSource getFluidSource() {
+        return fluidSource;
+    }
+
+    /**
+     * From where survival autoplace will drain fluid.
+     * <p>
+     * This is the fluid source this environment has been given, or what the actor can offer when the actor is a server
+     * side player: the {@linkplain com.gtnewhorizon.structurelib.fluid.FluidSourceProviders registered fluid source
+     * providers}, e.g. the ME network behind a wireless terminal the player has on them, and then the fluid containers
+     * the player is carrying. It is null when the actor isn't a server side player and no fluid source has been given,
+     * in which case fluid blocks cannot be placed at all.
+     */
+    @Nullable
+    public IFluidSource getEffectiveFluidSource() {
+        if (fluidSource != null) return fluidSource;
+        if (actor instanceof EntityPlayerMP) return FluidSourceProviders.getSourceFor((EntityPlayerMP) actor);
+        return null;
     }
 
     /**
@@ -142,32 +208,149 @@ public class AutoPlaceEnvironment {
 
     /**
      * Return a new instance with source modified to given value.
+     * <p>
+     * The returned instance shares the fluid source, and every bookkeeping about the current autoplace round, with this
+     * one.
      *
      * @param source new source
      * @return new instance
      */
     public AutoPlaceEnvironment withSource(IItemSource source) {
-        return new AutoPlaceEnvironment(source, actor, chatter, definition, piece, facing, offsetABC, baseOffsetABC);
+        return new AutoPlaceEnvironment(
+                source,
+                fluidSource,
+                actor,
+                chatter,
+                definition,
+                piece,
+                facing,
+                offsetABC,
+                baseOffsetABC,
+                basePositionXYZ,
+                contextObject,
+                fluidRoundState);
     }
 
     /**
      * Return a new instance with actor modified to given value.
+     * <p>
+     * The returned instance shares the fluid source, and every bookkeeping about the current autoplace round, with this
+     * one.
      *
      * @param actor new actor
      * @return new instance
      */
     public AutoPlaceEnvironment withActor(EntityPlayer actor) {
-        return new AutoPlaceEnvironment(source, actor, chatter, definition, piece, facing, offsetABC, baseOffsetABC);
+        return new AutoPlaceEnvironment(
+                source,
+                fluidSource,
+                actor,
+                chatter,
+                definition,
+                piece,
+                facing,
+                offsetABC,
+                baseOffsetABC,
+                basePositionXYZ,
+                contextObject,
+                fluidRoundState);
     }
 
     /**
      * Return a new instance with chatter modified to given value.
+     * <p>
+     * The returned instance shares the fluid source, and every bookkeeping about the current autoplace round, with this
+     * one.
      *
      * @param chatter new chatter
      * @return new instance
      */
     public AutoPlaceEnvironment withChatter(Consumer<IChatComponent> chatter) {
-        return new AutoPlaceEnvironment(source, actor, chatter, definition, piece, facing, offsetABC, baseOffsetABC);
+        return new AutoPlaceEnvironment(
+                source,
+                fluidSource,
+                actor,
+                chatter,
+                definition,
+                piece,
+                facing,
+                offsetABC,
+                baseOffsetABC,
+                basePositionXYZ,
+                contextObject,
+                fluidRoundState);
+    }
+
+    /**
+     * Return a new instance with an explicit fluid source.
+     * <p>
+     * This is how a multiblock that wants its fluid to come from somewhere else than the player inventory, e.g. from a
+     * tank, hands its fluid source to autoplace.
+     *
+     * @param fluidSource new fluid source
+     * @return new instance
+     */
+    public AutoPlaceEnvironment withFluidSource(@Nullable IFluidSource fluidSource) {
+        return new AutoPlaceEnvironment(
+                source,
+                fluidSource,
+                actor,
+                chatter,
+                definition,
+                piece,
+                facing,
+                offsetABC,
+                baseOffsetABC,
+                basePositionXYZ,
+                contextObject,
+                fluidRoundState);
+    }
+
+    IStructureDefinition<?> getDefinition() {
+        return definition;
+    }
+
+    String getPiece() {
+        return piece;
+    }
+
+    int[] getBaseOffsetABC() {
+        return baseOffsetABC;
+    }
+
+    @Nullable
+    int[] getBasePositionXYZ() {
+        return basePositionXYZ;
+    }
+
+    @Nullable
+    Object getContextObject() {
+        return contextObject;
+    }
+
+    /**
+     * The answer to the fluid placement gate of the current autoplace round, or null when it has not been asked yet.
+     */
+    @Nullable
+    Boolean getFluidGateResult() {
+        return fluidRoundState == null ? null : fluidRoundState.getGateResult();
+    }
+
+    void setFluidGateResult(boolean ready) {
+        if (fluidRoundState != null) fluidRoundState.setGateResult(ready);
+    }
+
+    /**
+     * Flag that at least one fluid element wanted to place its fluid, but had to wait for the structure to be built
+     * first. An autoplace round that did nothing but wait reports zero placed elements instead of reporting that the
+     * structure is done.
+     */
+    void markFluidPlacementDeferred() {
+        if (fluidRoundState != null) fluidRoundState.markDeferred();
+    }
+
+    boolean isFluidPlacementDeferred() {
+        return fluidRoundState != null && fluidRoundState.isDeferred();
     }
 
     private static class WrappedIItemSource implements IItemSource {
@@ -205,6 +388,34 @@ public class AutoPlaceEnvironment {
         public boolean takeAll(ItemStack stack, boolean simulate) {
             return delegate.takeAll(stack, simulate);
         }
+    }
+
+    /**
+     * Bookkeeping about the current autoplace round, shared by every instance {@link AutoPlaceEnvironment} hands out
+     * for itself. Implemented by the autoplace walker. Third parties should neither implement nor call this.
+     */
+    public interface FluidRoundState {
+
+        /**
+         * The answer the fluid placement gate gave earlier in this round, or null when it has not been asked yet.
+         */
+        @Nullable
+        Boolean getGateResult();
+
+        /**
+         * Remember the answer of the fluid placement gate for the rest of this round.
+         */
+        void setGateResult(boolean ready);
+
+        /**
+         * Remember that a fluid element had to wait for the structure to be built first.
+         */
+        void markDeferred();
+
+        /**
+         * Whether any fluid element had to wait for the structure to be built in this round.
+         */
+        boolean isDeferred();
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/AutoPlaceEnvironment.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/AutoPlaceEnvironment.java
@@ -340,6 +340,10 @@ public class AutoPlaceEnvironment {
         if (fluidRoundState != null) fluidRoundState.setGateResult(ready);
     }
 
+    void clearFluidGateResult() {
+        if (fluidRoundState != null) fluidRoundState.clearGateResult();
+    }
+
     /**
      * Flag that at least one fluid element wanted to place its fluid, but had to wait for the structure to be built
      * first. An autoplace round that did nothing but wait reports zero placed elements instead of reporting that the
@@ -406,6 +410,15 @@ public class AutoPlaceEnvironment {
          * Remember the answer of the fluid placement gate for the rest of this round.
          */
         void setGateResult(boolean ready);
+
+        /**
+         * Forget the answer of the fluid placement gate, so that it is asked again.
+         * <p>
+         * The answer describes the world as it was before this round built anything, so it has to be dropped once the
+         * round has placed something and the fluids that had to wait are retried. An implementation that keeps no
+         * answer at all can leave this alone.
+         */
+        default void clearGateResult() {}
 
         /**
          * Remember that a fluid element had to wait for the structure to be built first.

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/DefaultSurvivalBuildEnvironment.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/DefaultSurvivalBuildEnvironment.java
@@ -1,20 +1,35 @@
 package com.gtnewhorizon.structurelib.structure;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.player.EntityPlayer;
+
+import com.gtnewhorizon.structurelib.fluid.IFluidSource;
 
 class DefaultSurvivalBuildEnvironment implements ISurvivalBuildEnvironment {
 
     private final IItemSource source;
+    private final IFluidSource fluidSource;
     private final EntityPlayer actor;
 
     public DefaultSurvivalBuildEnvironment(IItemSource source, EntityPlayer actor) {
+        this(source, null, actor);
+    }
+
+    public DefaultSurvivalBuildEnvironment(IItemSource source, @Nullable IFluidSource fluidSource, EntityPlayer actor) {
         this.source = source;
+        this.fluidSource = fluidSource;
         this.actor = actor;
     }
 
     @Override
     public IItemSource getSource() {
         return source;
+    }
+
+    @Override
+    public IFluidSource getFluidSource() {
+        return fluidSource;
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
@@ -1,0 +1,323 @@
+package com.gtnewhorizon.structurelib.structure;
+
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidBlock;
+
+import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluid;
+import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluidName;
+import com.gtnewhorizon.structurelib.ConfigurationHandler;
+import com.gtnewhorizon.structurelib.StructureLib;
+import com.gtnewhorizon.structurelib.StructureLibAPI;
+import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.fluid.FluidAmounts;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockRequirement;
+import com.gtnewhorizon.structurelib.fluid.FluidFillPolicy;
+import com.gtnewhorizon.structurelib.fluid.IFluidSource;
+import com.gtnewhorizon.structurelib.structure.IStructureElement.PlaceResult;
+
+/**
+ * Autoplace of fluid blocks.
+ * <p>
+ * Placing a fluid is not the same as placing a block. A block stays where it was put, while a fluid flows out of an
+ * unfinished structure, floods the surroundings, and turns a partially filled position into something that no longer
+ * counts as a source block. This class handles that:
+ * <ul>
+ * <li>It only places a fluid once the rest of the structure is in place, so that the fluid has something to hold it.
+ * See {@link GateMode} for how strict that gate is.</li>
+ * <li>It charges only for the fluid that is actually missing from a position, so topping a position up after a leak
+ * costs the difference instead of a whole bucket.</li>
+ * <li>It only consumes fluid after the block has been placed successfully, and puts the previous block back if the
+ * fluid turns out to be gone by then.</li>
+ * </ul>
+ * Structure elements reach this class through
+ * {@link StructureUtility#survivalPlaceBlock(Block, int, World, int, int, int, IItemSource, EntityPlayer, Consumer)} or
+ * {@link StructureUtility#ofFluidBlock(Block, int)}, and custom elements may call
+ * {@link #tryPlace(World, int, int, int, AutoPlaceEnvironment, FluidBlockRequirement)} directly.
+ */
+public class FluidAutoplace {
+
+    /**
+     * How careful autoplace is about placing a fluid into a structure that is not finished yet.
+     */
+    public enum GateMode {
+        /**
+         * Place the fluid right away. The fluid can flow out of the unfinished structure.
+         */
+        NONE,
+        /**
+         * Only place the fluid when none of its six neighbours is a position that the fluid can flow into and that
+         * doesn't belong to the structure. The fluid can still flow into the part of the structure that is not built
+         * yet, but it cannot leave the structure.
+         */
+        LENIENT,
+        /**
+         * Only place the fluid once every non fluid element of the structure is satisfied. This is the default, and
+         * together with the fact that an autoplace round places a limited number of elements it effectively builds the
+         * structure first and fills it with fluid afterwards.
+         */
+        STRICT
+    }
+
+    private FluidAutoplace() {}
+
+    /**
+     * Try to place a fluid block, draining the fluid from the autoplace environment's fluid source.
+     * <p>
+     * Nothing is consumed when this returns anything other than {@link PlaceResult#ACCEPT}, and the block that was
+     * there before is put back when the fluid cannot be taken after the block has been placed.
+     *
+     * @param world       world to place in
+     * @param x           x coord
+     * @param y           y coord
+     * @param z           z coord
+     * @param env         autoplace environment, providing the fluid source, the actor and the chatter
+     * @param requirement which block the structure wants there, what it costs, and how strict the check is
+     * @return {@link PlaceResult#SKIP} when the position is already good enough, {@link PlaceResult#ACCEPT} when the
+     *         fluid block has been placed, {@link PlaceResult#REJECT_CONTINUE} when the structure is not ready for its
+     *         fluid yet or fluid autoplace is off, and {@link PlaceResult#REJECT} when the fluid is missing
+     */
+    public static PlaceResult tryPlace(World world, int x, int y, int z, AutoPlaceEnvironment env,
+            FluidBlockRequirement requirement) {
+        if (world.isRemote || !ConfigurationHandler.INSTANCE.isFluidAutoplaceEnabled()) {
+            return PlaceResult.REJECT_CONTINUE;
+        }
+        if (isSatisfied(world, x, y, z, requirement)) return PlaceResult.SKIP;
+        if (!canReplace(world, x, y, z, env.getActor())) return PlaceResult.REJECT;
+        if (!isGateOpen(world, x, y, z, env)) {
+            env.markFluidPlacementDeferred();
+            return PlaceResult.REJECT_CONTINUE;
+        }
+        IFluidSource source = env.getEffectiveFluidSource();
+        if (source == null) {
+            reportMissingFluid(env, requirement, requirement.cost().amount);
+            return PlaceResult.REJECT;
+        }
+        Block existingBlock = world.getBlock(x, y, z);
+        int existingMeta = world.getBlockMetadata(x, y, z);
+        int target = requirement.cost().amount;
+        int existing = existingBlock == requirement.block() ? FluidAmounts.getStoredAmount(world, x, y, z, target) : 0;
+        int missing = Math.max(0, target - existing);
+        if (missing > 0 && !source.takeAll(new FluidStack(requirement.cost(), missing), true)) {
+            reportMissingFluid(
+                    env,
+                    requirement,
+                    missing - source.getAvailable(new FluidStack(requirement.cost(), missing)));
+            return PlaceResult.REJECT;
+        }
+        if (!placeFluidBlock(world, x, y, z, requirement)) return PlaceResult.REJECT;
+        if (missing > 0 && !source.takeAll(new FluidStack(requirement.cost(), missing), false)) {
+            restore(world, x, y, z, existingBlock, existingMeta);
+            return PlaceResult.REJECT;
+        }
+        return PlaceResult.ACCEPT;
+    }
+
+    /**
+     * Try to place one of several fluid blocks, in order, and stop at the first one that is already there or that could
+     * be placed.
+     *
+     * @return the result of the first attempt that was more than a {@link PlaceResult#REJECT_CONTINUE}, or
+     *         {@link PlaceResult#REJECT} when the fluid of an alternative was missing, or
+     *         {@link PlaceResult#REJECT_CONTINUE} when every alternative had to wait
+     * @see #tryPlace(World, int, int, int, AutoPlaceEnvironment, FluidBlockRequirement)
+     */
+    public static PlaceResult tryPlace(World world, int x, int y, int z, AutoPlaceEnvironment env,
+            Iterable<FluidBlockRequirement> requirements) {
+        PlaceResult result = PlaceResult.REJECT_CONTINUE;
+        for (FluidBlockRequirement requirement : requirements) {
+            PlaceResult attempt = tryPlace(world, x, y, z, env, requirement);
+            if (attempt == PlaceResult.REJECT_CONTINUE) continue;
+            if (attempt == PlaceResult.REJECT) {
+                result = PlaceResult.REJECT;
+                continue;
+            }
+            return attempt;
+        }
+        return result;
+    }
+
+    /**
+     * Whether the position already holds as much fluid as the structure asks for.
+     * <p>
+     * This is what a fluid structure element uses for its check, so that a check and an autoplace always agree.
+     *
+     * @param world       world to look at
+     * @param x           x coord
+     * @param y           y coord
+     * @param z           z coord
+     * @param requirement which block the structure wants there, and how strict the check is
+     */
+    public static boolean isSatisfied(World world, int x, int y, int z, FluidBlockRequirement requirement) {
+        Block worldBlock = world.getBlock(x, y, z);
+        if (worldBlock != requirement.block()) return false;
+        if (world.getBlockMetadata(x, y, z) == requirement.meta()) return true;
+        if (requirement.policy() == FluidFillPolicy.EXACT_STATE) return false;
+        int target = requirement.cost().amount;
+        return requirement.policy().isSatisfied(FluidAmounts.getStoredAmount(world, x, y, z, target), target);
+    }
+
+    /**
+     * Put the fluid block into the world without paying for it, which is what a creative mode build does.
+     * <p>
+     * Unlike {@link #tryPlace(World, int, int, int, AutoPlaceEnvironment, FluidBlockRequirement)} this does not check
+     * whether the structure is ready to hold the fluid. A creative mode build places everything that isn't a fluid
+     * first for that reason.
+     *
+     * @return true if the block has been placed
+     */
+    public static boolean place(World world, int x, int y, int z, FluidBlockRequirement requirement) {
+        return placeFluidBlock(world, x, y, z, requirement);
+    }
+
+    /**
+     * A human readable description of what a structure element expects at one position, e.g. {@code Water (1000 mB)}.
+     */
+    public static String describe(FluidBlockRequirement requirement) {
+        FluidStack stack = requirement.cost();
+        return StatCollector
+                .translateToLocalFormatted("structurelib.fluid.requirement", stack.getLocalizedName(), stack.amount);
+    }
+
+    /**
+     * Whether a fluid may be placed at this position right now.
+     * <p>
+     * With {@link GateMode#STRICT} the answer is computed once per autoplace round and cached on the environment, as it
+     * costs a walk over the whole structure. That also means a fluid is at worst one round late, which is what keeps
+     * the walk cheap on big multiblocks.
+     *
+     * @param world world to place in
+     * @param x     x coord
+     * @param y     y coord
+     * @param z     z coord
+     * @param env   autoplace environment
+     */
+    public static boolean isGateOpen(World world, int x, int y, int z, AutoPlaceEnvironment env) {
+        GateMode mode = ConfigurationHandler.INSTANCE.getFluidGateMode();
+        if (mode == GateMode.NONE) return true;
+        if (mode == GateMode.LENIENT) return isLocallyContained(world, x, y, z, env);
+        Boolean cached = env.getFluidGateResult();
+        if (cached != null) return cached;
+        boolean ready = isStructureReady(world, env);
+        env.setFluidGateResult(ready);
+        return ready;
+    }
+
+    /**
+     * Whether every non fluid element of the structure is satisfied, i.e. whether the structure is built far enough to
+     * hold the fluid.
+     * <p>
+     * An autoplace environment that doesn't know its structure, e.g. one handed to a legacy caller, always answers
+     * true, as there is nothing to be checked against.
+     */
+    private static boolean isStructureReady(World world, AutoPlaceEnvironment env) {
+        IStructureDefinition<?> definition = env.getDefinition();
+        int[] base = env.getBasePositionXYZ();
+        if (definition == null || base == null) return true;
+        Object context = env.getContextObject();
+        int[] baseOffset = env.getBaseOffsetABC();
+        ExtendedFacing facing = env.getFacing();
+        IStructureElement<Object>[] elements = getElements(definition, env.getPiece());
+        if (elements == null) return true;
+        return StructureUtility.iterateV2(
+                elements,
+                world,
+                facing,
+                base[0],
+                base[1],
+                base[2],
+                baseOffset[0],
+                baseOffset[1],
+                baseOffset[2],
+                (element, w, ex, ey, ez, a, b, c) -> element.isFluidElement(context)
+                        || element.check(context, w, ex, ey, ez),
+                "fluid gate");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private static IStructureElement<Object>[] getElements(IStructureDefinition<?> definition, String piece) {
+        try {
+            return (IStructureElement<Object>[]) definition.getStructureFor(piece);
+        } catch (RuntimeException e) {
+            StructureLib.LOGGER
+                    .warn("Could not look up structure piece {} to check whether it can hold fluid", piece, e);
+            return null;
+        }
+    }
+
+    /**
+     * Whether the fluid cannot flow out of the structure from this position, i.e. whether every neighbour is either
+     * blocked, or part of the structure and therefore eventually filled by it.
+     */
+    private static boolean isLocallyContained(World world, int x, int y, int z, AutoPlaceEnvironment env) {
+        ExtendedFacing facing = env.getFacing();
+        // An environment that doesn't know the structure cannot tell which neighbours belong to it. Don't block then.
+        if (facing == null) return true;
+        int[] abcOffset = new int[3];
+        int[] xyzOffset = new int[3];
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            int nx = x + direction.offsetX;
+            int ny = y + direction.offsetY;
+            int nz = z + direction.offsetZ;
+            if (isBlocking(world, nx, ny, nz)) continue;
+            xyzOffset[0] = direction.offsetX;
+            xyzOffset[1] = direction.offsetY;
+            xyzOffset[2] = direction.offsetZ;
+            facing.getOffsetABC(xyzOffset, abcOffset);
+            if (env.isContainedInPiece(abcOffset[0], abcOffset[1], abcOffset[2])) continue;
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isBlocking(World world, int x, int y, int z) {
+        Block block = world.getBlock(x, y, z);
+        if (block == null) return true;
+        if (block.isAir(world, x, y, z)) return false;
+        if (block.getMaterial() != null && block.getMaterial().isLiquid()) return false;
+        return !block.isReplaceable(world, x, y, z);
+    }
+
+    private static boolean canReplace(World world, int x, int y, int z, EntityPlayer actor) {
+        Block block = world.getBlock(x, y, z);
+        if (block == null || block.isAir(world, x, y, z)) return true;
+        if (block.getMaterial() != null && block.getMaterial().isLiquid()) return true;
+        if (block instanceof IFluidBlock) return true;
+        return StructureLibAPI.isBlockTriviallyReplaceable(world, x, y, z, actor);
+    }
+
+    private static boolean placeFluidBlock(World world, int x, int y, int z, FluidBlockRequirement requirement) {
+        FluidStack fluid = requirement.cost();
+        if (requirement.placer() != null) {
+            return requirement.placer().place(world, x, y, z, requirement.block(), requirement.meta(), fluid);
+        }
+        return world.setBlock(x, y, z, requirement.block(), requirement.meta(), 2);
+    }
+
+    private static void restore(World world, int x, int y, int z, Block block, int meta) {
+        if (block == null || block.isAir(world, x, y, z)) world.setBlockToAir(x, y, z);
+        else world.setBlock(x, y, z, block, meta, 2);
+    }
+
+    private static void reportMissingFluid(AutoPlaceEnvironment env, FluidBlockRequirement requirement, int missing) {
+        Consumer<IChatComponent> chatter = env.getChatter();
+        if (chatter == null) return;
+        FluidStack stack = new FluidStack(requirement.cost(), Math.max(1, missing));
+        chatter.accept(
+                new ChatComponentTranslation(
+                        "structurelib.autoplace.missing_fluid",
+                        new ChatComponentFluidName(stack),
+                        new ChatComponentFluid(stack)));
+    }
+}

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fluids.IFluidBlock;
 
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluid;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluidName;
+import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil;
 import com.gtnewhorizon.structurelib.ConfigurationHandler;
 import com.gtnewhorizon.structurelib.StructureLib;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
@@ -181,12 +182,14 @@ public class FluidAutoplace {
     }
 
     /**
-     * A human readable description of what a structure element expects at one position, e.g. {@code Water (1000 mB)}.
+     * Returns a human-readable description of the structure element requirement.
      */
     public static String describe(FluidBlockRequirement requirement) {
         FluidStack stack = requirement.cost();
-        return StatCollector
-                .translateToLocalFormatted("structurelib.fluid.requirement", stack.getLocalizedName(), stack.amount);
+        return StatCollector.translateToLocalFormatted(
+                "structurelib.autoplace.requirement_fluid",
+                stack.getLocalizedName(),
+                NumberFormatUtil.formatFluid(stack.amount));
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
@@ -63,9 +63,11 @@ public class FluidAutoplace {
          */
         LENIENT,
         /**
-         * Only place the fluid once every non fluid element of the structure is satisfied. This is the default, and
-         * together with the fact that an autoplace round places a limited number of elements it effectively builds the
-         * structure first and fills it with fluid afterwards.
+         * Only place the fluid once every non fluid element of the structure is satisfied. This is the default.
+         * <p>
+         * The fluid is placed as soon as the structure can hold it, which is normally the round that finishes the
+         * structure: the fluids that round could not place yet are tried once more when it is done building, so they do
+         * not have to wait for another round.
          */
         STRICT
     }
@@ -195,9 +197,9 @@ public class FluidAutoplace {
     /**
      * Whether a fluid may be placed at this position right now.
      * <p>
-     * With {@link GateMode#STRICT} the answer is computed once per autoplace round and cached on the environment, as it
-     * costs a walk over the whole structure. That also means a fluid is at worst one round late, which is what keeps
-     * the walk cheap on big multiblocks.
+     * With {@link GateMode#STRICT} the answer is computed by a walk over the whole structure and cached for the rest of
+     * the round, as that walk is expensive. The cache is dropped as soon as the round has built something, so that the
+     * fluids which waited for it are not held back by an answer that predates those placements.
      *
      * @param world world to place in
      * @param x     x coord
@@ -302,15 +304,23 @@ public class FluidAutoplace {
 
     private static boolean placeFluidBlock(World world, int x, int y, int z, FluidBlockRequirement requirement) {
         FluidStack fluid = requirement.cost();
+        Block block = requirement.block();
         if (requirement.placer() != null) {
-            return requirement.placer().place(world, x, y, z, requirement.block(), requirement.meta(), fluid);
+            if (!requirement.placer().place(world, x, y, z, block, requirement.meta(), fluid)) return false;
+        } else {
+            // The notification flags matter here. A fluid that is put into the world silently neither flows nor tells
+            // its neighbours about itself, so it would sit where it was placed until something else happens to touch
+            // it, which for water inside a multiblock can be never.
+            if (!world.setBlock(x, y, z, block, requirement.meta(), 3)) return false;
         }
-        return world.setBlock(x, y, z, requirement.block(), requirement.meta(), 2);
+        // A fluid that is never ticked does not spread, and a fluid placed as a flowing one would never settle.
+        world.scheduleBlockUpdate(x, y, z, block, block.tickRate(world));
+        return true;
     }
 
     private static void restore(World world, int x, int y, int z, Block block, int meta) {
         if (block == null || block.isAir(world, x, y, z)) world.setBlockToAir(x, y, z);
-        else world.setBlock(x, y, z, block, meta, 2);
+        else world.setBlock(x, y, z, block, meta, 3);
     }
 
     private static void reportMissingFluid(AutoPlaceEnvironment env, FluidBlockRequirement requirement, int missing) {

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/FluidAutoplace.java
@@ -319,8 +319,7 @@ public class FluidAutoplace {
     }
 
     private static void restore(World world, int x, int y, int z, Block block, int meta) {
-        if (block == null || block.isAir(world, x, y, z)) world.setBlockToAir(x, y, z);
-        else world.setBlock(x, y, z, block, meta, 3);
+        StructureLibAPI.restoreBlock(world, x, y, z, block, meta);
     }
 
     private static void reportMissingFluid(AutoPlaceEnvironment env, FluidBlockRequirement requirement, int missing) {

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureDefinition.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureDefinition.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import com.gtnewhorizon.structurelib.ConfigurationHandler;
 import com.gtnewhorizon.structurelib.StructureLib;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
@@ -303,6 +304,7 @@ public interface IStructureDefinition<T> {
                 piece,
                 extendedFacing,
                 new int[] { basePositionA, basePositionB, basePositionC },
+                new int[] { basePositionX, basePositionY, basePositionZ },
                 check);
         StructureUtility.iterateV2(
                 getStructureFor(piece),
@@ -418,7 +420,7 @@ public interface IStructureDefinition<T> {
                             return true;
                         }),
                         "spawnHint");
-            } else {
+            } else if (ConfigurationHandler.INSTANCE.getFluidGateMode() == FluidAutoplace.GateMode.NONE) {
                 StructureUtility.iterateV2(
                         elements,
                         world,
@@ -434,6 +436,40 @@ public interface IStructureDefinition<T> {
                             return true;
                         }),
                         "placeBlock");
+            } else {
+                // Build everything that isn't a fluid first, then fill the structure with fluid. That way a fluid has
+                // something holding it by the time it is placed. This is the creative mode counterpart of the fluid
+                // placement gate that survival autoplace uses.
+                StructureUtility.iterateV2(
+                        elements,
+                        world,
+                        extendedFacing,
+                        basePositionX,
+                        basePositionY,
+                        basePositionZ,
+                        basePositionA,
+                        basePositionB,
+                        basePositionC,
+                        ignoreBlockUnloaded((e, w, x, y, z, a, b, c) -> {
+                            if (!e.isFluidElement(object)) e.placeBlock(object, world, x, y, z, trigger);
+                            return true;
+                        }),
+                        "placeBlock");
+                StructureUtility.iterateV2(
+                        elements,
+                        world,
+                        extendedFacing,
+                        basePositionX,
+                        basePositionY,
+                        basePositionZ,
+                        basePositionA,
+                        basePositionB,
+                        basePositionC,
+                        ignoreBlockUnloaded((e, w, x, y, z, a, b, c) -> {
+                            if (e.isFluidElement(object)) e.placeBlock(object, world, x, y, z, trigger);
+                            return true;
+                        }),
+                        "placeFluid");
             }
         }
         return true;

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureDefinition.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureDefinition.java
@@ -318,6 +318,9 @@ public interface IStructureDefinition<T> {
                 basePositionC,
                 walker,
                 "survivalBuild");
+        // A fluid position is often visited before the blocks that hold it, so give the fluids that had to wait for
+        // those blocks a chance to be placed in this round rather than the next one.
+        walker.finishRound(world);
         return walker.getBuilt();
     }
 

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElement.java
@@ -3,6 +3,7 @@ package com.gtnewhorizon.structurelib.structure;
 import static com.gtnewhorizon.structurelib.StructureLib.LOGGER;
 import static com.gtnewhorizon.structurelib.StructureLib.PANIC_MODE;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -22,6 +23,10 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.world.World;
 
 import com.gtnewhorizon.structurelib.StructureLibAPI;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockPlacement;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockRequirement;
+import com.gtnewhorizon.structurelib.fluid.FluidFillPolicy;
+import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
 import com.gtnewhorizon.structurelib.util.ItemStackPredicate;
 import com.gtnewhorizon.structurelib.util.ItemStackPredicate.NBTMode;
 
@@ -126,6 +131,23 @@ public interface IStructureElement<T> {
     }
 
     /**
+     * Whether this element is responsible for placing fluid blocks, e.g. an element that accepts a water block created
+     * by {@link StructureUtility#ofBlock(Block, int)} or {@link StructureUtility#ofFluidBlock(Block, int)}.
+     * <p>
+     * Autoplace uses this to keep a fluid from flowing out of a structure that is not finished yet: a fluid is only
+     * placed once every element that does not answer true has been satisfied. An element that wraps another element
+     * must forward this call, otherwise a fluid inside of it is treated as a block that still has to be built, and is
+     * never placed at all.
+     * <p>
+     * The default is false, which is the safe answer for every element that was written before fluid autoplace existed.
+     *
+     * @param t the context object, used to resolve an element that is built on demand
+     */
+    default boolean isFluidElement(T t) {
+        return false;
+    }
+
+    /**
      * Try place the block by taking resource from given {@link IItemSource}.
      * <p>
      * You might want to use
@@ -140,7 +162,7 @@ public interface IStructureElement<T> {
      * <li>call {@link #check(Object, World, int, int, int)}. If this returns {@code true}, {@link PlaceResult#SKIP}
      * will be returned without further action.</li>
      * <li>Use the {@link BlocksToPlace} retrieved earlier and passed in {@link IItemSource} to determine an item to
-     * place</li>
+     * place, or the fluid it carries to place a fluid block</li>
      * <li>Hand over control to
      * {@link StructureUtility#survivalPlaceBlock(ItemStack, NBTMode, NBTTagCompound, boolean, World, int, int, int, IItemSource, EntityPlayer, Consumer)}</li>
      * </ol>
@@ -170,6 +192,10 @@ public interface IStructureElement<T> {
             if (check(t, world, x, y, z)) return PlaceResult.SKIP;
             if (e.getStacks() == null) {
                 ItemStack taken = source.takeOne(e.getPredicate(), true);
+                if (taken == null) {
+                    return e.getFluidRequirements().isEmpty() ? PlaceResult.REJECT
+                            : FluidAutoplace.tryPlace(world, x, y, z, env, e.getFluidRequirements());
+                }
                 return StructureUtility.survivalPlaceBlock(
                         taken,
                         NBTMode.EXACT,
@@ -198,7 +224,8 @@ public interface IStructureElement<T> {
                         actor,
                         chatter);
             }
-            return PlaceResult.REJECT;
+            return e.getFluidRequirements().isEmpty() ? PlaceResult.REJECT
+                    : FluidAutoplace.tryPlace(world, x, y, z, env, e.getFluidRequirements());
         }
         if (actor instanceof EntityPlayerMP)
             return survivalPlaceBlock(t, world, x, y, z, trigger, source, (EntityPlayerMP) actor, chatter);
@@ -305,6 +332,7 @@ public interface IStructureElement<T> {
         public static final BlocksToPlace errored = createEmpty();
         private final Predicate<ItemStack> predicate;
         private final Iterable<ItemStack> stacks;
+        private final List<FluidBlockRequirement> fluidRequirements;
 
         public static BlocksToPlace createEmpty() {
             return new BlocksToPlace(s -> false, Collections.emptyList());
@@ -326,8 +354,22 @@ public interface IStructureElement<T> {
             return new BlocksToPlace(predicate, stacks);
         }
 
+        /**
+         * Accept a block state, describing what has to be paid for it.
+         * <p>
+         * A block that has no item form, e.g. a fluid block, is described by what it costs to place it with fluid. Such
+         * a block can only be placed in survival mode when fluid autoplace knows how to pay for it.
+         */
         public static BlocksToPlace create(Block block, int meta) {
+            FluidBlockPlacement placement = FluidPlacementRegistry.resolve(block, meta);
             Item itemBlock = Item.getItemFromBlock(block);
+            if (itemBlock == null) {
+                if (placement == null) return createEmpty();
+                return createFluid(FluidBlockRequirement.of(placement, block, meta, FluidFillPolicy.EXACT_STATE));
+            }
+            if (placement != null && placement.forceFluid()) {
+                return createFluid(FluidBlockRequirement.of(placement, block, meta, FluidFillPolicy.EXACT_STATE));
+            }
             if (itemBlock instanceof ISpecialItemBlock) {
                 meta = ((ISpecialItemBlock) itemBlock).getItemMetaFromBlockMeta(block, meta);
             }
@@ -348,9 +390,33 @@ public interface IStructureElement<T> {
             return new BlocksToPlace(predicate, null);
         }
 
+        /**
+         * Describe a block state that is paid for with fluid instead of with an item.
+         */
+        public static BlocksToPlace createFluid(FluidBlockRequirement... requirements) {
+            return createFluid(Arrays.asList(requirements));
+        }
+
+        /**
+         * Describe block states that are paid for with fluid instead of with an item.
+         */
+        public static BlocksToPlace createFluid(Iterable<FluidBlockRequirement> requirements) {
+            List<FluidBlockRequirement> list = new ArrayList<>();
+            for (FluidBlockRequirement requirement : requirements) {
+                if (requirement != null) list.add(requirement);
+            }
+            return new BlocksToPlace(s -> false, Collections.emptyList(), list);
+        }
+
         BlocksToPlace(Predicate<ItemStack> predicate, Iterable<ItemStack> stacks) {
+            this(predicate, stacks, Collections.emptyList());
+        }
+
+        BlocksToPlace(Predicate<ItemStack> predicate, Iterable<ItemStack> stacks,
+                List<FluidBlockRequirement> fluidRequirements) {
             this.predicate = predicate;
             this.stacks = stacks;
+            this.fluidRequirements = fluidRequirements;
         }
 
         /**
@@ -376,6 +442,19 @@ public interface IStructureElement<T> {
         @Nullable
         public Iterable<ItemStack> getStacks() {
             return stacks;
+        }
+
+        /**
+         * Get the block states that this one is known to accept, and that have to be paid for with fluid.
+         * <p>
+         * Suitable for use with {@link FluidAutoplace#tryPlace(World, int, int, int, AutoPlaceEnvironment, Iterable)}.
+         * Item forms are tried first, so this is only consulted when no item was found.
+         *
+         * @return a possibly empty list. never null. do not mutate it.
+         */
+        @Nonnull
+        public List<FluidBlockRequirement> getFluidRequirements() {
+            return fluidRequirements;
         }
     }
 }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/IStructureElementChain.java
@@ -15,6 +15,7 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.world.World;
 
 import com.google.common.collect.Iterables;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockRequirement;
 
 /**
  * Use StructureUtility to instantiate
@@ -53,6 +54,18 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
         return false;
     }
 
+    /**
+     * A chain counts as a fluid element as soon as one of its fallbacks is one, as the fluid it places is paid for with
+     * fluid even though another fallback might have been satisfied by an item.
+     */
+    @Override
+    default boolean isFluidElement(T t) {
+        for (IStructureElement<T> fallback : fallbacks()) {
+            if (fallback.isFluidElement(t)) return true;
+        }
+        return false;
+    }
+
     @Override
     default boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
         for (IStructureElement<T> fallback : fallbacks()) {
@@ -82,6 +95,7 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
             AutoPlaceEnvironment env) {
         Predicate<ItemStack> predicate = null;
         List<Iterable<ItemStack>> is = new ArrayList<>();
+        List<FluidBlockRequirement> fluids = new ArrayList<>();
         for (IStructureElement<T> fallback : fallbacks()) {
             BlocksToPlace e = fallback.getBlocksToPlace(t, world, x, y, z, trigger, env);
             if (e == null) continue;
@@ -89,9 +103,10 @@ public interface IStructureElementChain<T> extends IStructureElement<T> {
             else predicate = predicate.or(e.getPredicate());
             Iterable<ItemStack> stacks = e.getStacks();
             if (stacks != null) is.add(stacks);
+            fluids.addAll(e.getFluidRequirements());
         }
         if (predicate == null) return null;
-        return new BlocksToPlace(predicate, Iterables.concat(is));
+        return new BlocksToPlace(predicate, Iterables.concat(is), fluids);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/ISurvivalBuildEnvironment.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/ISurvivalBuildEnvironment.java
@@ -1,10 +1,13 @@
 package com.gtnewhorizon.structurelib.structure;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.fluid.FluidSourceProviders;
+import com.gtnewhorizon.structurelib.fluid.IFluidSource;
 
 /*
  * Architecture notes: this should never get any callback from survival build. All structure significant code belongs
@@ -23,11 +26,85 @@ public interface ISurvivalBuildEnvironment {
     IItemSource getSource();
 
     /**
+     * Get the source of the fluid, which autoplace drains when a structure element has to place a fluid block.
+     * <p>
+     * Returning null is fine, and is what every existing implementation does. Autoplace then falls back to draining the
+     * fluid containers held by {@link #getActor()} when it is a server side player, and refuses to place fluid blocks
+     * when there is no way to pay for them at all.
+     * <p>
+     * A multiblock that wants its fluid to come from somewhere else than the player inventory, e.g. from its own tank,
+     * returns its own source here. A multiblock that receives an environment from its caller can wrap it with
+     * {@link #withFluidSource(ISurvivalBuildEnvironment, IFluidSource)}. See {@link IFluidSource} for the sources
+     * StructureLib can build out of the box.
+     */
+    default IFluidSource getFluidSource() {
+        return null;
+    }
+
+    /**
+     * Get the fluid source autoplace will actually drain from, which is the source this environment has been given, or
+     * a source built from what the actor can offer when there is none and the actor is a server side player: first
+     * every provider registered with {@link FluidSourceProviders}, then the fluid containers the actor is carrying.
+     * <p>
+     * This is what a multiblock that wants to put a source of its own in front of the player's own ones combines it
+     * with, e.g. to prefer an ME network it is attached to and keep the player's buckets as a fallback:
+     *
+     * <pre>
+     * env = ISurvivalBuildEnvironment.withFluidSource(
+     *         env,
+     *         IFluidSource.composite(IFluidSource.fromHandler(myTank), env.getEffectiveFluidSource()));
+     * </pre>
+     *
+     * @return the source, or null when there is none, i.e. when the actor isn't a server side player and no source has
+     *         been given
+     */
+    default IFluidSource getEffectiveFluidSource() {
+        IFluidSource source = getFluidSource();
+        if (source != null) return source;
+        if (getActor() instanceof EntityPlayerMP) return FluidSourceProviders.getSourceFor((EntityPlayerMP) getActor());
+        return null;
+    }
+
+    /**
      * Get the origin of action. This will be invoked at least once per
      * {@link IStructureDefinition#survivalBuild(Object, ItemStack, String, World, ExtendedFacing, int, int, int, int, int, int, int, ISurvivalBuildEnvironment, boolean)}
      * call.
      */
     EntityPlayer getActor();
+
+    /**
+     * Replace the fluid source of an environment, keeping everything else the same.
+     * <p>
+     * This is what a multiblock uses when it wants its fluid to come from its own tank instead of from the player, as
+     * the environment it receives comes from its caller:
+     *
+     * <pre>
+     * env = ISurvivalBuildEnvironment.withFluidSource(env, IFluidSource.fromHandler(myTank));
+     * </pre>
+     *
+     * @param env         the environment to take the item source and the actor from
+     * @param fluidSource the fluid source to use, or null to fall back to the player inventory
+     */
+    static ISurvivalBuildEnvironment withFluidSource(ISurvivalBuildEnvironment env, IFluidSource fluidSource) {
+        if (env == null) throw new IllegalArgumentException();
+        return new ISurvivalBuildEnvironment() {
+
+            @Override
+            public IItemSource getSource() {
+                return env.getSource();
+            }
+
+            @Override
+            public IFluidSource getFluidSource() {
+                return fluidSource;
+            }
+
+            @Override
+            public EntityPlayer getActor() {
+                return env.getActor();
+            }
+        };
+    }
 
     /**
      * Create a default implementation with three parameters all being constants.
@@ -36,6 +113,17 @@ public interface ISurvivalBuildEnvironment {
      * @param actor  source of action
      */
     static ISurvivalBuildEnvironment create(IItemSource source, EntityPlayer actor) {
-        return new DefaultSurvivalBuildEnvironment(source, actor);
+        return new DefaultSurvivalBuildEnvironment(source, null, actor);
+    }
+
+    /**
+     * Create a default implementation with three parameters all being constants.
+     *
+     * @param source      from where to drain items
+     * @param fluidSource from where to drain fluid, or null to drain the fluid containers held by the actor
+     * @param actor       source of action
+     */
+    static ISurvivalBuildEnvironment create(IItemSource source, IFluidSource fluidSource, EntityPlayer actor) {
+        return new DefaultSurvivalBuildEnvironment(source, fluidSource, actor);
     }
 }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/LazyStructureElement.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/LazyStructureElement.java
@@ -48,6 +48,12 @@ class LazyStructureElement<T> implements IStructureElementDeferred<T> {
         return get(t).spawnHint(t, world, x, y, z, trigger);
     }
 
+    @Override
+    public boolean isFluidElement(T t) {
+        IStructureElement<T> element = get(t);
+        return element != null && element.isFluidElement(t);
+    }
+
     @Nullable
     @Override
     public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -1963,6 +1963,32 @@ public class StructureUtility {
         return ofFluidBlock(block, meta, new FluidStack(fluid, amount), policy);
     }
 
+    /**
+     * Accept a fluid block, and pay for it with {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of the given fluid.
+     *
+     * @param fluid the fluid one block of this state costs
+     * @param block the fluid block
+     * @param meta  the block meta that has to be there
+     * @see #ofFluid(Fluid, int, Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluid(Fluid fluid, Block block, int meta) {
+        return ofFluid(fluid, block, meta, FluidFillPolicy.EXACT_STATE);
+    }
+
+    /**
+     * Accept a fluid block, and pay for it with {@link FluidPlacementRegistry#DEFAULT_FLUID_AMOUNT} of the given fluid.
+     *
+     * @param fluid  the fluid one block of this state costs
+     * @param block  the fluid block
+     * @param meta   the block meta that has to be there
+     * @param policy how much fluid an already partially filled position has to hold to be accepted as is
+     * @see #ofFluid(Fluid, int, Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluid(Fluid fluid, Block block, int meta, FluidFillPolicy policy) {
+        if (fluid == null) throw new IllegalArgumentException();
+        return ofFluidBlock(block, meta, FluidBlockPlacement.of(fluid), policy);
+    }
+
     // endregion
 
     // region adders

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -4,6 +4,7 @@ import static com.gtnewhorizon.structurelib.StructureLib.LOGGER;
 import static com.gtnewhorizon.structurelib.StructureLib.PANIC_MODE;
 import static java.lang.Integer.MIN_VALUE;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,16 +45,23 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.google.common.collect.ImmutableList;
+import com.gtnewhorizon.structurelib.ConfigurationHandler;
 import com.gtnewhorizon.structurelib.StructureEvent.StructureElementVisitedEvent;
 import com.gtnewhorizon.structurelib.StructureLib;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockPlacement;
+import com.gtnewhorizon.structurelib.fluid.FluidBlockRequirement;
+import com.gtnewhorizon.structurelib.fluid.FluidFillPolicy;
+import com.gtnewhorizon.structurelib.fluid.FluidPlacementRegistry;
+import com.gtnewhorizon.structurelib.structure.IStructureElement.BlocksToPlace;
 import com.gtnewhorizon.structurelib.structure.IStructureElement.PlaceResult;
 import com.gtnewhorizon.structurelib.structure.adders.IBlockAdder;
 import com.gtnewhorizon.structurelib.structure.adders.ITileAdder;
@@ -121,6 +129,19 @@ import cpw.mods.fml.common.registry.GameRegistry;
  * <li>{@link #isAir()}, {@link #notAir()}: They are supplied by default under the identifier {@code '-'} and
  * {@code '+'} respectively, but are provided here regardless in case you want to use them as a fallback.</li>
  * </ul>
+ * <h3>Fluid Element</h3> These accept a fluid block, e.g. a water source block, and pay for it by draining fluid from
+ * the autoplace environment's fluid source instead of by taking an item. See {@link FluidAutoplace} for how a fluid is
+ * kept from flowing out of a structure that is not finished yet, and {@link FluidPlacementRegistry} for what a fluid
+ * block costs.
+ * <ul>
+ * <li>{@link #ofFluidBlock(Block, int)} and its overloads: cost and placement are taken from the registry, or stated
+ * explicitly</li>
+ * <li>{@link #ofFluid(Fluid, int, Block, int)} and its overloads: the same, stating the fluid and the amount to pay in
+ * the code of the structure definition</li>
+ * </ul>
+ * Note that {@link #ofBlock(Block, int)} and the other block elements automatically become a fluid element when the
+ * block has no item form, e.g. for water and lava, so an existing structure definition needs no change to have its
+ * fluid positions filled.
  * <h3>Complex Block Element</h3> In case your logic on determining which block is accepted is complex, use these.
  * <ul>
  * <li>{@link #ofBlockAdder(IBlockAdder, Block, int)}, {@link #ofBlockAdderHint(IBlockAdder, Block, int)} and their
@@ -266,6 +287,99 @@ public class StructureUtility {
     private StructureUtility() {}
 
     /**
+     * What it costs to place this block state with fluid, or null when autoplace has to use the item form of this
+     * block.
+     * <p>
+     * A block state that has an item form keeps using it, unless its registration with {@link FluidPlacementRegistry}
+     * asked for fluid to be preferred. This is what keeps blocks that are both a fluid block and an item behaving the
+     * way they did before fluid autoplace existed.
+     */
+    @Nullable
+    private static FluidBlockPlacement resolveFluidPlacement(Block block, int meta) {
+        if (block == null || !ConfigurationHandler.INSTANCE.isFluidAutoplaceEnabled()) return null;
+        FluidBlockPlacement placement = FluidPlacementRegistry.resolve(block, meta);
+        if (placement == null) return null;
+        if (placement.forceFluid() || !FluidPlacementRegistry.hasItemForm(block)) return placement;
+        return null;
+    }
+
+    private static boolean hasFluidPlacementFlat(Map<Block, Integer> blocsMap) {
+        for (Entry<Block, Integer> e : blocsMap.entrySet()) {
+            if (resolveFluidPlacement(e.getKey(), e.getValue()) != null) return true;
+        }
+        return false;
+    }
+
+    private static boolean hasFluidPlacementMap(Map<Block, Collection<Integer>> blocsMap) {
+        for (Entry<Block, Collection<Integer>> e : blocsMap.entrySet()) {
+            for (int meta : e.getValue()) {
+                if (resolveFluidPlacement(e.getKey(), meta) != null) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Describe how to place any one of the given block states, one meta per block.
+     * <p>
+     * A state that cannot be paid for with an item, e.g. a fluid block, is described by what it costs to place it with
+     * fluid instead.
+     */
+    private static BlocksToPlace blocksToPlaceOfBlocksFlat(Map<Block, Integer> blocsMap) {
+        List<ItemStack> blocks = new ArrayList<>();
+        List<FluidBlockRequirement> fluids = new ArrayList<>();
+        Predicate<ItemStack> predicate = s -> false;
+        for (Entry<Block, Integer> e : blocsMap.entrySet()) {
+            Block block = e.getKey();
+            int meta = e.getValue();
+            FluidBlockPlacement placement = resolveFluidPlacement(block, meta);
+            Item i = Item.getItemFromBlock(block);
+            if (placement != null && (i == null || placement.forceFluid())) {
+                fluids.add(FluidBlockRequirement.of(placement, block, meta, FluidFillPolicy.EXACT_STATE));
+                continue;
+            }
+            if (i == null) continue;
+            int itemMeta = i instanceof ISpecialItemBlock
+                    ? ((ISpecialItemBlock) i).getItemMetaFromBlockMeta(block, meta)
+                    : meta;
+            ItemStack stack = new ItemStack(i, 1, itemMeta);
+            blocks.add(stack);
+            predicate = predicate.or(ItemStackPredicate.from(stack));
+        }
+        return new BlocksToPlace(predicate, blocks, fluids);
+    }
+
+    /**
+     * Describe how to place any one of the given block states, with a set of accepted metas per block.
+     *
+     * @see #blocksToPlaceOfBlocksFlat(Map)
+     */
+    private static BlocksToPlace blocksToPlaceOfBlocksMap(Map<Block, Collection<Integer>> blocsMap) {
+        List<ItemStack> blocks = new ArrayList<>();
+        List<FluidBlockRequirement> fluids = new ArrayList<>();
+        Predicate<ItemStack> predicate = s -> false;
+        for (Entry<Block, Collection<Integer>> e : blocsMap.entrySet()) {
+            Block block = e.getKey();
+            for (int meta : e.getValue()) {
+                FluidBlockPlacement placement = resolveFluidPlacement(block, meta);
+                Item i = Item.getItemFromBlock(block);
+                if (placement != null && (i == null || placement.forceFluid())) {
+                    fluids.add(FluidBlockRequirement.of(placement, block, meta, FluidFillPolicy.EXACT_STATE));
+                    continue;
+                }
+                if (i == null) continue;
+                int itemMeta = i instanceof ISpecialItemBlock
+                        ? ((ISpecialItemBlock) i).getItemMetaFromBlockMeta(block, meta)
+                        : meta;
+                ItemStack stack = new ItemStack(i, 1, itemMeta);
+                blocks.add(stack);
+                predicate = predicate.or(ItemStackPredicate.from(stack));
+            }
+        }
+        return new BlocksToPlace(predicate, blocks, fluids);
+    }
+
+    /**
      * This is a helper method for implementing
      * {@link IStructureElement#survivalPlaceBlock(Object, World, int, int, int, ItemStack, IItemSource, EntityPlayerMP, Consumer)}
      * <p>
@@ -352,8 +466,25 @@ public class StructureUtility {
     public static PlaceResult survivalPlaceBlock(Block block, int meta, World world, int x, int y, int z, IItemSource s,
             EntityPlayer actor, Consumer<IChatComponent> chatter) {
         if (block == null) throw new NullPointerException();
+        FluidBlockPlacement fluidPlacement = resolveFluidPlacement(block, meta);
+        if (fluidPlacement != null) {
+            // A fluid block is paid for with fluid. Either it has no item form at all, or its registration asked for
+            // fluid to be preferred over the item form.
+            return FluidAutoplace.tryPlace(
+                    world,
+                    x,
+                    y,
+                    z,
+                    AutoPlaceEnvironment.fromLegacy(s, actor, chatter),
+                    FluidBlockRequirement.of(fluidPlacement, block, meta, FluidFillPolicy.EXACT_STATE));
+        }
         if (!StructureLibAPI.isBlockTriviallyReplaceable(world, x, y, z, actor)) return PlaceResult.REJECT;
         Item itemBlock = Item.getItemFromBlock(block);
+        if (itemBlock == null) {
+            // A block without an item form and without a fluid placement cannot be placed by taking a resource. This
+            // used to be a null pointer exception.
+            return PlaceResult.REJECT_CONTINUE;
+        }
         int itemMeta = itemBlock instanceof ISpecialItemBlock
                 ? ((ISpecialItemBlock) itemBlock).getItemMetaFromBlockMeta(block, meta)
                 : meta;
@@ -727,7 +858,7 @@ public class StructureUtility {
             Function<T, TIER> getter) {
         List<String> descriptions = null;
         if (allKnownTiers != null) {
-            descriptions = new java.util.ArrayList<>();
+            descriptions = new ArrayList<>();
             for (Pair<Block, Integer> tier : allKnownTiers) {
                 Item item = Item.getItemFromBlock(tier.getLeft());
                 if (item != null) {
@@ -918,6 +1049,12 @@ public class StructureUtility {
             }
 
             @Override
+            public boolean isFluidElement(T t) {
+                Block block = getBlock();
+                return block != null && resolveFluidPlacement(block, meta) != null;
+            }
+
+            @Override
             public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
                     AutoPlaceEnvironment env) {
                 if (check(t, world, x, y, z)) return PlaceResult.SKIP;
@@ -1001,6 +1138,12 @@ public class StructureUtility {
                     AutoPlaceEnvironment env) {
                 if (init()) return BlocksToPlace.create(block, meta);
                 return fallback.getBlocksToPlace(t, world, x, y, z, trigger, env);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                if (init()) return resolveFluidPlacement(block, meta) != null;
+                return fallback.isFluidElement(t);
             }
 
             @Override
@@ -1226,21 +1369,13 @@ public class StructureUtility {
                 @Override
                 public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
                         AutoPlaceEnvironment env) {
-                    if (blocksToPlace == null) {
-                        ImmutableList.Builder<ItemStack> blocks = ImmutableList.builder();
-                        Predicate<ItemStack> predicate = s -> true;
-                        for (Entry<Block, Integer> e : blocsMap.entrySet()) {
-                            Item i = Item.getItemFromBlock(e.getKey());
-                            int meta = e.getValue();
-                            if (i instanceof ISpecialItemBlock)
-                                meta = ((ISpecialItemBlock) i).getItemMetaFromBlockMeta(e.getKey(), meta);
-                            ItemStack stack = new ItemStack(i, 1, meta);
-                            blocks.add(stack);
-                            predicate = predicate.and(ItemStackPredicate.from(stack));
-                        }
-                        blocksToPlace = new BlocksToPlace(predicate, blocks.build());
-                    }
+                    if (blocksToPlace == null) blocksToPlace = blocksToPlaceOfBlocksFlat(blocsMap);
                     return blocksToPlace;
+                }
+
+                @Override
+                public boolean isFluidElement(T t) {
+                    return hasFluidPlacementFlat(blocsMap);
                 }
             };
         } else {
@@ -1274,21 +1409,13 @@ public class StructureUtility {
                 @Override
                 public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
                         AutoPlaceEnvironment env) {
-                    if (blocksToPlace == null) {
-                        ImmutableList.Builder<ItemStack> blocks = ImmutableList.builder();
-                        Predicate<ItemStack> predicate = s -> true;
-                        for (Entry<Block, Integer> e : blocsMap.entrySet()) {
-                            Item i = Item.getItemFromBlock(e.getKey());
-                            int meta = e.getValue();
-                            if (i instanceof ISpecialItemBlock)
-                                meta = ((ISpecialItemBlock) i).getItemMetaFromBlockMeta(e.getKey(), meta);
-                            ItemStack stack = new ItemStack(i, 1, meta);
-                            blocks.add(stack);
-                            predicate = predicate.and(ItemStackPredicate.from(stack));
-                        }
-                        blocksToPlace = new BlocksToPlace(predicate, blocks.build());
-                    }
+                    if (blocksToPlace == null) blocksToPlace = blocksToPlaceOfBlocksFlat(blocsMap);
                     return blocksToPlace;
+                }
+
+                @Override
+                public boolean isFluidElement(T t) {
+                    return hasFluidPlacementFlat(blocsMap);
                 }
             };
         }
@@ -1344,22 +1471,13 @@ public class StructureUtility {
                 @Override
                 public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
                         AutoPlaceEnvironment env) {
-                    if (blocksToPlace == null) {
-                        ImmutableList.Builder<ItemStack> blocks = ImmutableList.builder();
-                        Predicate<ItemStack> predicate = s -> true;
-                        for (Entry<Block, Collection<Integer>> e : blocsMap.entrySet()) {
-                            Item i = Item.getItemFromBlock(e.getKey());
-                            for (int meta : e.getValue()) {
-                                if (i instanceof ISpecialItemBlock)
-                                    meta = ((ISpecialItemBlock) i).getItemMetaFromBlockMeta(e.getKey(), meta);
-                                ItemStack stack = new ItemStack(i, 1, meta);
-                                blocks.add(stack);
-                                predicate = predicate.and(ItemStackPredicate.from(stack));
-                            }
-                        }
-                        blocksToPlace = new BlocksToPlace(predicate, blocks.build());
-                    }
+                    if (blocksToPlace == null) blocksToPlace = blocksToPlaceOfBlocksMap(blocsMap);
                     return blocksToPlace;
+                }
+
+                @Override
+                public boolean isFluidElement(T t) {
+                    return hasFluidPlacementMap(blocsMap);
                 }
             };
         } else {
@@ -1394,22 +1512,13 @@ public class StructureUtility {
                 @Override
                 public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
                         AutoPlaceEnvironment env) {
-                    if (blocksToPlace == null) {
-                        ImmutableList.Builder<ItemStack> blocks = ImmutableList.builder();
-                        Predicate<ItemStack> predicate = s -> true;
-                        for (Entry<Block, Collection<Integer>> e : blocsMap.entrySet()) {
-                            Item i = Item.getItemFromBlock(e.getKey());
-                            for (int meta : e.getValue()) {
-                                if (i instanceof ISpecialItemBlock)
-                                    meta = ((ISpecialItemBlock) i).getItemMetaFromBlockMeta(e.getKey(), meta);
-                                ItemStack stack = new ItemStack(i, 1, meta);
-                                blocks.add(stack);
-                                predicate = predicate.and(ItemStackPredicate.from(stack));
-                            }
-                        }
-                        blocksToPlace = new BlocksToPlace(predicate, blocks.build());
-                    }
+                    if (blocksToPlace == null) blocksToPlace = blocksToPlaceOfBlocksMap(blocsMap);
                     return blocksToPlace;
+                }
+
+                @Override
+                public boolean isFluidElement(T t) {
+                    return hasFluidPlacementMap(blocsMap);
                 }
             };
         }
@@ -1417,6 +1526,10 @@ public class StructureUtility {
 
     /**
      * Accept a block. Spawn hint/autoplace using another.
+     * <p>
+     * A fluid block, e.g. water or lava, has no item form, and is placed by draining fluid from the autoplace
+     * environment's fluid source instead. See {@link FluidPlacementRegistry} for what a fluid block costs, and
+     * {@link #ofFluidBlock(Block, int)} for a variant that states the fluid explicitly.
      *
      * @param block        accepted block
      * @param meta         accepted meta
@@ -1435,8 +1548,14 @@ public class StructureUtility {
                 return isAir();
             }
         }
+        FluidBlockPlacement fluidPlacement = resolveFluidPlacement(block, meta);
+        if (fluidPlacement != null) {
+            return ofFluidBlock(block, meta, defaultBlock, defaultMeta, fluidPlacement, FluidFillPolicy.EXACT_STATE);
+        }
         if (block instanceof ICustomBlockSetting) {
             return new IStructureElement<T>() {
+
+                private BlocksToPlace blocksToPlace;
 
                 @Override
                 public boolean check(T t, World world, int x, int y, int z) {
@@ -1477,6 +1596,8 @@ public class StructureUtility {
             };
         } else {
             return new IStructureElement<T>() {
+
+                private BlocksToPlace blocksToPlace;
 
                 @Override
                 public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
@@ -1551,7 +1672,9 @@ public class StructureUtility {
                 @Override
                 public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
                         AutoPlaceEnvironment env) {
-                    return BlocksToPlace.create(block, meta);
+                    // What this state can be paid with never changes, so it is built once instead of on every visit.
+                    if (blocksToPlace == null) blocksToPlace = BlocksToPlace.create(block, meta);
+                    return blocksToPlace;
                 }
 
                 @Nullable
@@ -1604,6 +1727,11 @@ public class StructureUtility {
                     return BlocksToPlace.create(defaultBlock, defaultMeta);
                 }
 
+                @Override
+                public boolean isFluidElement(T t) {
+                    return resolveFluidPlacement(defaultBlock, defaultMeta) != null;
+                }
+
                 @Nullable
                 @Override
                 public List<String> getDescription(T context) {
@@ -1644,6 +1772,11 @@ public class StructureUtility {
                     return BlocksToPlace.create(defaultBlock, defaultMeta);
                 }
 
+                @Override
+                public boolean isFluidElement(T t) {
+                    return resolveFluidPlacement(defaultBlock, defaultMeta) != null;
+                }
+
                 @Nullable
                 @Override
                 public List<String> getDescription(T context) {
@@ -1674,6 +1807,160 @@ public class StructureUtility {
      */
     public static <T> IStructureElement<T> ofBlockAnyMeta(Block block, int defaultMeta) {
         return ofBlockAnyMeta(block, block, defaultMeta);
+    }
+
+    /**
+     * Accept a fluid block, e.g. a water or lava source block, and pay for it with fluid instead of with an item.
+     * <p>
+     * What one block of this state costs, and how it is written into the world, is taken from
+     * {@link FluidPlacementRegistry}, which knows about water and lava by default and recognises every Forge fluid
+     * block. Use one of the overloads below to state the fluid explicitly instead.
+     * <p>
+     * A fluid placed into a structure that is not finished yet would flow out of it, so fluid autoplace waits until the
+     * rest of the structure is in place. See {@link FluidAutoplace} for the details.
+     *
+     * @param block the fluid block
+     * @param meta  the block meta that has to be there, which is 0 for the source block of a vanilla style liquid
+     * @throws IllegalArgumentException if this block state is not a fluid block at all
+     */
+    public static <T> IStructureElement<T> ofFluidBlock(Block block, int meta) {
+        if (block == null) throw new IllegalArgumentException();
+        FluidBlockPlacement placement = FluidPlacementRegistry.resolve(block, meta);
+        if (placement == null) throw new IllegalArgumentException("Not a fluid block: " + block.getUnlocalizedName());
+        return ofFluidBlock(block, meta, placement, FluidFillPolicy.EXACT_STATE);
+    }
+
+    /**
+     * Accept a fluid block, and pay for it with the given amount of fluid.
+     *
+     * @see #ofFluidBlock(Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluidBlock(Block block, int meta, FluidStack cost) {
+        return ofFluidBlock(block, meta, cost, FluidFillPolicy.EXACT_STATE);
+    }
+
+    /**
+     * Accept a fluid block, and pay for it with the given amount of fluid.
+     *
+     * @param policy how much fluid an already partially filled position has to hold to be accepted as is
+     * @see #ofFluidBlock(Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluidBlock(Block block, int meta, FluidStack cost,
+            FluidFillPolicy policy) {
+        return ofFluidBlock(block, meta, FluidBlockPlacement.of(cost), policy);
+    }
+
+    /**
+     * Accept a fluid block, and pay for it the way the given placement says.
+     *
+     * @param placement what this block state costs, and how to place it
+     * @param policy    how much fluid an already partially filled position has to hold to be accepted as is
+     * @see #ofFluidBlock(Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluidBlock(Block block, int meta, FluidBlockPlacement placement,
+            FluidFillPolicy policy) {
+        return ofFluidBlock(block, meta, block, meta, placement, policy);
+    }
+
+    /**
+     * The implementation behind every fluid element factory.
+     *
+     * @param block     the block the structure wants there
+     * @param meta      the block meta the structure wants there
+     * @param hintBlock block to spawn the hint with, which is not necessarily the accepted one
+     * @param hintMeta  meta to spawn the hint with
+     */
+    private static <T> IStructureElement<T> ofFluidBlock(Block block, int meta, Block hintBlock, int hintMeta,
+            FluidBlockPlacement placement, FluidFillPolicy policy) {
+        if (block == null) throw new IllegalArgumentException();
+        if (placement == null) throw new IllegalArgumentException();
+        if (policy == null) throw new IllegalArgumentException();
+        FluidBlockRequirement requirement = FluidBlockRequirement.of(placement, block, meta, policy);
+        BlocksToPlace blocksToPlace = BlocksToPlace.createFluid(requirement);
+        return new IStructureElement<T>() {
+
+            @Override
+            public boolean check(T t, World world, int x, int y, int z) {
+                return FluidAutoplace.isSatisfied(world, x, y, z, requirement);
+            }
+
+            @Override
+            public boolean couldBeValid(T t, World world, int x, int y, int z, ItemStack trigger) {
+                return check(t, world, x, y, z);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                return true;
+            }
+
+            @Override
+            public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
+                return FluidAutoplace.place(world, x, y, z, requirement);
+            }
+
+            @Override
+            public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
+                StructureLibAPI.hintParticle(world, x, y, z, hintBlock, hintMeta);
+                return true;
+            }
+
+            @Override
+            public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
+                    AutoPlaceEnvironment env) {
+                return FluidAutoplace.tryPlace(world, x, y, z, env, requirement);
+            }
+
+            @Override
+            public PlaceResult survivalPlaceBlock(T t, World world, int x, int y, int z, ItemStack trigger,
+                    IItemSource s, EntityPlayerMP actor, Consumer<IChatComponent> chatter) {
+                return FluidAutoplace
+                        .tryPlace(world, x, y, z, AutoPlaceEnvironment.fromLegacy(s, actor, chatter), requirement);
+            }
+
+            @Nullable
+            @Override
+            public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
+                    AutoPlaceEnvironment env) {
+                return blocksToPlace;
+            }
+
+            @Nullable
+            @Override
+            public List<String> getDescription(T context) {
+                // Translated on demand, as elements are built before the language files are loaded.
+                return Collections.singletonList(FluidAutoplace.describe(requirement));
+            }
+        };
+    }
+
+    /**
+     * Accept a fluid block, and pay for it with the given amount of the given fluid.
+     *
+     * @param fluid  the fluid one block of this state costs
+     * @param amount how much of it one block costs
+     * @param block  the fluid block
+     * @param meta   the block meta that has to be there
+     * @see #ofFluidBlock(Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluid(Fluid fluid, int amount, Block block, int meta) {
+        return ofFluid(fluid, amount, block, meta, FluidFillPolicy.EXACT_STATE);
+    }
+
+    /**
+     * Accept a fluid block, and pay for it with the given amount of the given fluid.
+     *
+     * @param fluid  the fluid one block of this state costs
+     * @param amount how much of it one block costs
+     * @param block  the fluid block
+     * @param meta   the block meta that has to be there
+     * @param policy how much fluid an already partially filled position has to hold to be accepted as is
+     * @see #ofFluidBlock(Block, int)
+     */
+    public static <T> IStructureElement<T> ofFluid(Fluid fluid, int amount, Block block, int meta,
+            FluidFillPolicy policy) {
+        if (fluid == null) throw new IllegalArgumentException();
+        return ofFluidBlock(block, meta, new FluidStack(fluid, amount), policy);
     }
 
     // endregion
@@ -1735,6 +2022,11 @@ public class StructureUtility {
                             env.getActor(),
                             env.getChatter());
                 }
+
+                @Override
+                public boolean isFluidElement(T t) {
+                    return resolveFluidPlacement(defaultBlock, defaultMeta) != null;
+                }
             };
         } else {
             return new StructureElement_Bridge<T>() {
@@ -1780,6 +2072,11 @@ public class StructureUtility {
                             env.getSource(),
                             env.getActor(),
                             env.getChatter());
+                }
+
+                @Override
+                public boolean isFluidElement(T t) {
+                    return resolveFluidPlacement(defaultBlock, defaultMeta) != null;
                 }
             };
         }
@@ -1895,6 +2192,11 @@ public class StructureUtility {
                 return element.spawnHint(t, world, x, y, z, trigger);
             }
 
+            @Override
+            public boolean isFluidElement(T t) {
+                return element.isFluidElement(t);
+            }
+
             @Nullable
             @Override
             public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
@@ -1952,6 +2254,11 @@ public class StructureUtility {
             @Override
             public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return element.spawnHint(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                return element.isFluidElement(t);
             }
 
             @Nullable
@@ -2014,6 +2321,11 @@ public class StructureUtility {
             @Override
             public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return element.spawnHint(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                return element.isFluidElement(t);
             }
 
             @Nullable
@@ -2080,6 +2392,12 @@ public class StructureUtility {
             @Override
             public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return predicate.test(t) && downstream.spawnHint(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                // A disabled element places nothing, so its position still has to be built before fluid may flow in.
+                return predicate.test(t) && downstream.isFluidElement(t);
             }
 
             @Override
@@ -2190,6 +2508,11 @@ public class StructureUtility {
             }
 
             @Override
+            public boolean isFluidElement(T t) {
+                return elem.isFluidElement(t.getCurrentContext());
+            }
+
+            @Override
             public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return elem.placeBlock(t.getCurrentContext(), world, x, y, z, trigger);
             }
@@ -2288,6 +2611,12 @@ public class StructureUtility {
             }
 
             @Override
+            public boolean isFluidElement(T t) {
+                IStructureElement<T> element = to.get();
+                return element != null && element.isFluidElement(t);
+            }
+
+            @Override
             public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return to.get().spawnHint(t, world, x, y, z, trigger);
             }
@@ -2343,6 +2672,12 @@ public class StructureUtility {
             @Override
             public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return to.apply(t).placeBlock(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                IStructureElement<T> element = to.apply(t);
+                return element != null && element.isFluidElement(t);
             }
 
             @Override
@@ -2563,12 +2898,18 @@ public class StructureUtility {
             }
 
             @Override
+            public boolean isFluidElement(T t) {
+                IStructureElement<T> element = to.apply(t, null);
+                return element != null && element.isFluidElement(t);
+            }
+
+            @Override
             public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return to.apply(t, trigger).spawnHint(t, world, x, y, z, trigger);
             }
 
-            @Nullable
             @Override
+            @Nullable
             public BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z, ItemStack trigger,
                     AutoPlaceEnvironment env) {
                 return to.apply(t, trigger).getBlocksToPlace(t, world, x, y, z, trigger, env);
@@ -2757,6 +3098,13 @@ public class StructureUtility {
             @Override
             public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
                 return to.apply(t, trigger).placeBlock(t, world, x, y, z, trigger);
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                // check comes from toCheck, so the fluid gate has to look at the same element.
+                IStructureElement<T> element = toCheck.apply(t);
+                return element != null && element.isFluidElement(t);
             }
 
             @Override
@@ -3026,6 +3374,11 @@ public class StructureUtility {
                 // I hope a CREATIVE player know what he is doing...
                 // no warning for yah
                 return backing.placeBlock(t, world, x, y, z, ChannelDataAccessor.withChannel(trigger, channel));
+            }
+
+            @Override
+            public boolean isFluidElement(T t) {
+                return backing.isFluidElement(t);
             }
 
             @Nullable

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -194,7 +194,7 @@ public class StructureUtility {
 
         @Override
         public boolean placeBlock(Object o, World world, int x, int y, int z, ItemStack trigger) {
-            world.setBlock(x, y, z, Blocks.air, 0, 2);
+            world.setBlock(x, y, z, Blocks.air, 0, 3);
             return false;
         }
 
@@ -204,7 +204,8 @@ public class StructureUtility {
                 AutoPlaceEnvironment env) {
             if (check(o, world, x, y, z)) return PlaceResult.SKIP;
             if (!StructureLibAPI.isBlockTriviallyReplaceable(world, x, y, z, env.getActor())) return PlaceResult.REJECT;
-            world.setBlock(x, y, z, Blocks.air, 0, 2);
+            // Notify the neighbours, so that e.g. a fluid next to a position that had to be emptied flows back into it.
+            world.setBlock(x, y, z, Blocks.air, 0, 3);
             return PlaceResult.ACCEPT;
         }
     };
@@ -494,6 +495,8 @@ public class StructureUtility {
                     new ChatComponentTranslation("structurelib.autoplace.missing_block", getStackChatName(stack)));
             return PlaceResult.REJECT;
         }
+        Block previousBlock = world.getBlock(x, y, z);
+        int previousMeta = world.getBlockMetadata(x, y, z);
         if (block instanceof ICustomBlockSetting blockCustom) {
             blockCustom.setBlock(world, x, y, z, meta);
         } else if (!stack.copy()
@@ -501,8 +504,9 @@ public class StructureUtility {
                     return PlaceResult.REJECT;
                 }
         if (!s.takeOne(stack, false)) {
-            // rollback
-            world.setBlockToAir(x, y, z);
+            // Roll back to what was there before, which is often a fluid that this block was placed over, so that a
+            // position is never left empty by a placement that was not paid for.
+            StructureLibAPI.restoreBlock(world, x, y, z, previousBlock, previousMeta);
         }
         return PlaceResult.ACCEPT;
     }
@@ -600,11 +604,14 @@ public class StructureUtility {
                     new ChatComponentTranslation("structurelib.autoplace.missing_block", getStackChatName(stack)));
             return PlaceResult.REJECT;
         }
+        Block previousBlock = world.getBlock(x, y, z);
+        int previousMeta = world.getBlockMetadata(x, y, z);
         if (!stack.copy().tryPlaceItemIntoWorld(actor, world, x, y, z, ForgeDirection.UP.ordinal(), 0.5f, 0.5f, 0.5f))
             return PlaceResult.REJECT;
         if (!s.takeOne(stack, false))
-            // this is bad! probably an exploit somehow. Let's nullify the block we just placed instead
-            world.setBlockToAir(x, y, z);
+            // this is bad! probably an exploit somehow. Put back what was there instead of clearing the position, as
+            // that would destroy the fluid this block was placed over.
+            StructureLibAPI.restoreBlock(world, x, y, z, previousBlock, previousMeta);
         return PlaceResult.ACCEPT;
     }
 

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/StructureUtility.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.event.HoverEvent;
@@ -194,6 +195,9 @@ public class StructureUtility {
 
         @Override
         public boolean placeBlock(Object o, World world, int x, int y, int z, ItemStack trigger) {
+            // A position that holds a fluid is left alone, as emptying it destroys the fluid instead of just clearing
+            // the position. It is up to whatever else the structure allows there to deal with it.
+            if (holdsFluid(world, x, y, z)) return false;
             world.setBlock(x, y, z, Blocks.air, 0, 3);
             return false;
         }
@@ -203,12 +207,28 @@ public class StructureUtility {
         public PlaceResult survivalPlaceBlock(Object o, World world, int x, int y, int z, ItemStack trigger,
                 AutoPlaceEnvironment env) {
             if (check(o, world, x, y, z)) return PlaceResult.SKIP;
+            // Emptying a position that holds a fluid would destroy that fluid, which is not the same as clearing some
+            // grass out of the way. Defer instead, so that a fluid element this one is chained with, e.g. one asking
+            // for water, still gets its chance to turn the fluid into what the structure wants.
+            if (holdsFluid(world, x, y, z)) return PlaceResult.REJECT_CONTINUE;
             if (!StructureLibAPI.isBlockTriviallyReplaceable(world, x, y, z, env.getActor())) return PlaceResult.REJECT;
             // Notify the neighbours, so that e.g. a fluid next to a position that had to be emptied flows back into it.
             world.setBlock(x, y, z, Blocks.air, 0, 3);
             return PlaceResult.ACCEPT;
         }
     };
+
+    /**
+     * Whether the given position holds a fluid. Such a position is not merely occupied, as whatever removes the fluid
+     * destroys it, and a structure is often built where a fluid was placed by the player or leaked out of one.
+     */
+    private static boolean holdsFluid(World world, int x, int y, int z) {
+        Block block = world.getBlock(x, y, z);
+        if (block == null) return false;
+        if (FluidPlacementRegistry.getFluidOf(block) != null) return true;
+        Material material = block.getMaterial();
+        return material != null && material.isLiquid();
+    }
 
     @SuppressWarnings("rawtypes")
     private static final IStructureElement NOT_AIR = new StructureElement_Bridge() {

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/SurvivalBuildStructureWalker.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/SurvivalBuildStructureWalker.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizon.structurelib.structure;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
@@ -7,7 +9,7 @@ import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.structure.IStructureElement.PlaceResult;
 
-class SurvivalBuildStructureWalker<T> implements IStructureWalker<T> {
+class SurvivalBuildStructureWalker<T> implements IStructureWalker<T>, AutoPlaceEnvironment.FluidRoundState {
 
     final T object;
     final ItemStack trigger;
@@ -16,11 +18,14 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T> {
     private final boolean check;
     private int built = -1;
 
+    private Boolean fluidGateResult;
+    private boolean fluidDeferred;
+
     private final AutoPlaceEnvironment env;
 
     public SurvivalBuildStructureWalker(T object, ItemStack trigger, int elementBudget,
             ISurvivalBuildEnvironment params, IStructureDefinition<?> definition, String piece, ExtendedFacing facing,
-            int[] baseOffsetABC, boolean check) {
+            int[] baseOffsetABC, int[] basePositionXYZ, boolean check) {
         this.object = object;
         this.trigger = trigger;
         this.elementBudget = elementBudget;
@@ -33,7 +38,11 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T> {
                 definition,
                 piece,
                 facing,
-                baseOffsetABC);
+                baseOffsetABC,
+                basePositionXYZ,
+                object,
+                params.getFluidSource(),
+                this);
     }
 
     @Override
@@ -65,7 +74,34 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T> {
         }
     }
 
+    /**
+     * Number of elements this round has placed, or -1 when the structure is done.
+     * <p>
+     * A round that only had to wait for the structure to be built before it could place its fluid did not build
+     * anything, and the structure is not done either, so it reports no progress instead of reporting completion.
+     */
     public int getBuilt() {
-        return built;
+        return built == -1 && fluidDeferred ? 0 : built;
+    }
+
+    @Nullable
+    @Override
+    public Boolean getGateResult() {
+        return fluidGateResult;
+    }
+
+    @Override
+    public void setGateResult(boolean ready) {
+        fluidGateResult = ready;
+    }
+
+    @Override
+    public void markDeferred() {
+        fluidDeferred = true;
+    }
+
+    @Override
+    public boolean isDeferred() {
+        return fluidDeferred;
     }
 }

--- a/src/main/java/com/gtnewhorizon/structurelib/structure/SurvivalBuildStructureWalker.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/structure/SurvivalBuildStructureWalker.java
@@ -1,10 +1,14 @@
 package com.gtnewhorizon.structurelib.structure;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.structure.IStructureElement.PlaceResult;
@@ -20,6 +24,7 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T>, AutoPlaceE
 
     private Boolean fluidGateResult;
     private boolean fluidDeferred;
+    private final List<DeferredFluid<T>> deferredFluids = new ArrayList<>();
 
     private final AutoPlaceEnvironment env;
 
@@ -52,6 +57,11 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T>, AutoPlaceE
         env.offsetABC[2] = c;
         env.setSource(params.getSource());
         PlaceResult placeResult = element.survivalPlaceBlock(object, world, x, y, z, trigger, env);
+        if (placeResult == PlaceResult.REJECT_CONTINUE && element.isFluidElement(object)) {
+            // The fluid has to wait. Remember where it is, as this round may still build what it is waiting for, and
+            // then it can be placed before the round is over instead of one round later.
+            deferredFluids.add(new DeferredFluid<>(element, x, y, z, a, b, c));
+        }
         if (placeResult != PlaceResult.SKIP && placeResult != PlaceResult.REJECT_CONTINUE && built == -1) built = 0;
         switch (placeResult) {
             case SKIP:
@@ -72,6 +82,44 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T>, AutoPlaceE
             default:
                 throw new NullPointerException();
         }
+    }
+
+    /**
+     * Place the fluids that had to wait during this round, now that the round has built everything it was going to.
+     * <p>
+     * A fluid position is often visited before the blocks that are meant to hold it, so a round that finishes the
+     * structure would otherwise leave the fluid to the next round even though there is nothing left to wait for. The
+     * gate is asked again, as the answer it gave was about the world as it was before this round built anything.
+     * <p>
+     * Like the walk itself, this places at most as many elements as the round still has budget left, and whatever it
+     * cannot reach is left to the next round.
+     *
+     * @param world the world this round was run in
+     */
+    void finishRound(World world) {
+        if (deferredFluids.isEmpty()) return;
+        // A round that built nothing has not changed the answer of the gate either.
+        if (built <= 0) return;
+
+        int budget = elementBudget - built;
+        env.clearFluidGateResult();
+        for (DeferredFluid<T> deferred : deferredFluids) {
+            if (budget <= 0) break;
+            IStructureElement<T> element = deferred.element();
+            // The element has to see the same offsets and item source it saw during the walk, as elements may read
+            // channel data or take items through them.
+            env.offsetABC[0] = deferred.a();
+            env.offsetABC[1] = deferred.b();
+            env.offsetABC[2] = deferred.c();
+            env.setSource(params.getSource());
+            PlaceResult placeResult = element
+                    .survivalPlaceBlock(object, world, deferred.x(), deferred.y(), deferred.z(), trigger, env);
+            if (placeResult != PlaceResult.ACCEPT) continue;
+            if (check) element.check(object, world, deferred.x(), deferred.y(), deferred.z());
+            built += 1;
+            budget -= 1;
+        }
+        deferredFluids.clear();
     }
 
     /**
@@ -96,6 +144,11 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T>, AutoPlaceE
     }
 
     @Override
+    public void clearGateResult() {
+        fluidGateResult = null;
+    }
+
+    @Override
     public void markDeferred() {
         fluidDeferred = true;
     }
@@ -104,4 +157,10 @@ class SurvivalBuildStructureWalker<T> implements IStructureWalker<T>, AutoPlaceE
     public boolean isDeferred() {
         return fluidDeferred;
     }
+
+    /**
+     * A fluid position a round had to leave alone, kept so that it can be tried once more when the round is over.
+     */
+    @Desugar
+    private record DeferredFluid<T> (IStructureElement<T> element, int x, int y, int z, int a, int b, int c) {}
 }

--- a/src/main/java/com/gtnewhorizon/structurelib/util/InventoryIterable.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/util/InventoryIterable.java
@@ -24,6 +24,16 @@ public class InventoryIterable<Inv extends IInventory> implements Iterable<ItemS
         return inv;
     }
 
+    /**
+     * The slot this iteration stops at, exclusive, or -1 when it runs to the end of the inventory.
+     * <p>
+     * Callers that have to write into the inventory instead of iterating over it, e.g. because they replace a stack
+     * rather than removing it, need this to respect the same range the iterator uses.
+     */
+    public int getMaxSlot() {
+        return maxSlot;
+    }
+
     @Override
     public Iterator<ItemStack> iterator() {
         return new Iterator<ItemStack>() {

--- a/src/main/java/com/gtnewhorizon/structurelib/util/InventoryUtility.java
+++ b/src/main/java/com/gtnewhorizon/structurelib/util/InventoryUtility.java
@@ -97,6 +97,19 @@ public class InventoryUtility {
         return stackExtractors.getPlayerOrdering(player).iterator();
     }
 
+    /**
+     * Every inventory registered for the given player, in the order the player configured.
+     * <p>
+     * This is the set of inventories {@link #takeFromInventory(EntityPlayerMP, ItemStack, boolean)} walks, exposed so
+     * that a walk that is not item based, e.g. StructureLib taking fluid out of a container a player carries, can cover
+     * the same inventories without having to register anything of its own.
+     *
+     * @param player the player whose inventories to walk
+     */
+    public static Iterable<InventoryProvider<?>> getInventoryProviders(EntityPlayerMP player) {
+        return inventoryProviders.getPlayerOrdering(player);
+    }
+
     public static <Inv extends IInventory> InventoryProvider<InventoryIterable<Inv>> newInventoryProvider(
             Function<EntityPlayerMP, ? extends Inv> extractor) {
         return new InventoryProvider<InventoryIterable<Inv>>() {
@@ -120,6 +133,12 @@ public class InventoryUtility {
             @Override
             public boolean isAPIImplemented(APIType type) {
                 return type == APIType.MAIN;
+            }
+
+            @Override
+            @Nullable
+            public IInventory getInventory(ItemStack source, @Nullable EntityPlayerMP player) {
+                return extractor.apply(source);
             }
 
             @Override
@@ -299,6 +318,23 @@ public class InventoryUtility {
 
         default boolean isValidSource(ItemStack is, EntityPlayerMP player) {
             return true;
+        }
+
+        /**
+         * The inventory held by the given item stack, if it holds one.
+         * <p>
+         * An extractor for an item that contains an inventory is registered once for item extraction, and can hand that
+         * same inventory out here, so a walk that is not item based, e.g. StructureLib looking for a fluid container a
+         * player put in their backpack, reaches the backpack contents as well. Returning null is fine and means this
+         * extractor cannot hand out the inventory itself.
+         *
+         * @param source item stack that might hold an inventory
+         * @param player the player the stack belongs to, or null when it does not come from a player
+         * @return the inventory inside the given stack, or null
+         */
+        @Nullable
+        default IInventory getInventory(ItemStack source, @Nullable EntityPlayerMP player) {
+            return null;
         }
 
         /**

--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -216,6 +216,3 @@ structurelib.config.registries.fluidcontainerextractors.tooltip=Controls which w
 
 structurelib.config.registries.fluidsourceproviders=Fluid sources
 structurelib.config.registries.fluidsourceproviders.tooltip=Controls which additional ways of getting fluid are used during survival autoplace, e.g. an ME network the player can reach with a wireless terminal. Whatever the player is carrying is always used after these.
-
-structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc=ME network (wireless terminal)
-structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc.tooltip=Fills the fluid a multiblock needs straight out of the ME network behind the wireless terminal the player has on them, when the terminal is linked and in range of a wireless access point.

--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -199,3 +199,23 @@ structurelib.sortedregistry.inventoryproviders.5000-main-inventory=Main Player I
 structurelib.sortedregistry.inventoryproviders.5000-main-inventory.tooltip=36 slots of item in your main inventory. Armor slots excluded.
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=Ender Chest Inventory
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory.tooltip=Links to your vanilla ender chest inventory. Require at least one "ender backpack like" item in main inventory to work.
+
+structurelib.autoplace.missing_fluid=§cMissing fluid: %s (%s)
+structurelib.fluid.requirement=%s (%s mB)
+
+structurelib.config.common.autoplace.tooltip=Configurations that control how survival autoplace places blocks.
+structurelib.config.common.autoplace.fluidAutoplace.tooltip=Whether survival autoplace may place fluid blocks, e.g. the water a multiblock needs inside itself, by draining fluid from the player's fluid containers.\nA multiblock can also provide its own fluid source.\nThis only disables fluid blocks. Multiblocks keep working, they just cannot have those positions filled by autoplace.
+structurelib.config.common.autoplace.fluidGateMode.tooltip=How careful autoplace is about placing a fluid into a structure that is not finished yet, as a fluid would flow out of it.\nNONE: place the fluid right away.\nLENIENT: only place the fluid when it cannot flow out of the structure.\nSTRICT: only place the fluid once every non fluid element of the structure is satisfied.
+
+structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item=Forge fluid container item
+structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item.tooltip=Containers implementing Forge's IFluidContainerItem, e.g. most modded cells. They hold their fluid in their own NBT, so they are drained in place.
+structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry=Forge fluid container registry
+structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry.tooltip=Containers registered with Forge's FluidContainerRegistry, e.g. buckets. They are consumed as a whole, and are replaced by their empty container.
+structurelib.config.registries.fluidcontainerextractors=Fluid container extraction
+structurelib.config.registries.fluidcontainerextractors.tooltip=Controls which ways of pulling fluid out of an item are enabled during survival autoplace
+
+structurelib.config.registries.fluidsourceproviders=Fluid sources
+structurelib.config.registries.fluidsourceproviders.tooltip=Controls which additional ways of getting fluid are used during survival autoplace, e.g. an ME network the player can reach with a wireless terminal. Whatever the player is carrying is always used after these.
+
+structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc=ME network (wireless terminal)
+structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc.tooltip=Fills the fluid a multiblock needs straight out of the ME network behind the wireless terminal the player has on them, when the terminal is linked and in range of a wireless access point.

--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -53,6 +53,8 @@ structurelib.autoplace.error.no_simple_block=§cSuggested to place §r%s§c but 
 structurelib.autoplace.error.no_item_stack=§cSuggested to place block by using §r%s§c but none was found
 structurelib.autoplace.warning.no_explicit_channel=§6This structure depends on nonexistent sub channel §r%s§6. Using master channel instead.
 structurelib.autoplace.missing_block=§cMissing block: %s
+structurelib.autoplace.missing_fluid=§cMissing fluid: %s (%s)
+structurelib.autoplace.requirement_fluid=%s (%s)
 
 structurelib.blockhint.desc.0=Helps while building
 structurelib.blockhint.0.name=Hint 1 dot
@@ -191,6 +193,11 @@ structurelib.config.registries.stackextractors.tooltip=Controls which inventory-
 structurelib.config.registries.inventoryproviders=Inventory Providers
 structurelib.config.registries.inventoryproviders.tooltip=Controls which inventories functions are enabled during survival autoplace
 
+structurelib.config.registries.fluidstackextractors=Fluid Stack Extractors
+structurelib.config.registries.fluidstackextractors.tooltip=Controls which ways of pulling fluid out of an item are enabled during survival autoplace
+structurelib.config.registries.fluidsourceproviders=Fluid Source Providers
+structurelib.config.registries.fluidsourceproviders.tooltip=Controls which additional ways of getting fluid are used during survival autoplace, e.g. an ME network the player can reach with a wireless terminal. Whatever the player is carrying is always used after these.
+
 structurelib.configgui.enabled=Enabled Entry
 structurelib.configgui.disabled=Disabled Entry
 structurelib.configgui.drag.tooltip=Drag this button to reorder this element.
@@ -200,19 +207,11 @@ structurelib.sortedregistry.inventoryproviders.5000-main-inventory.tooltip=36 sl
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=Ender Chest Inventory
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory.tooltip=Links to your vanilla ender chest inventory. Require at least one "ender backpack like" item in main inventory to work.
 
-structurelib.autoplace.missing_fluid=§cMissing fluid: %s (%s)
-structurelib.fluid.requirement=%s (%s mB)
+structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item=Forge fluid container item
+structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item.tooltip=Containers implementing Forge's IFluidContainerItem, e.g. most modded cells. They hold their fluid in their own NBT, so they are drained in place.
+structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry=Forge fluid container registry
+structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry.tooltip=Containers registered with Forge's FluidContainerRegistry, e.g. buckets. They are consumed as a whole, and are replaced by their empty container.
 
 structurelib.config.common.autoplace.tooltip=Configurations that control how survival autoplace places blocks.
 structurelib.config.common.autoplace.fluidAutoplace.tooltip=Whether survival autoplace may place fluid blocks, e.g. the water a multiblock needs inside itself, by draining fluid from the player's fluid containers.\nA multiblock can also provide its own fluid source.\nThis only disables fluid blocks. Multiblocks keep working, they just cannot have those positions filled by autoplace.
 structurelib.config.common.autoplace.fluidGateMode.tooltip=How careful autoplace is about placing a fluid into a structure that is not finished yet, as a fluid would flow out of it.\nNONE: place the fluid right away.\nLENIENT: only place the fluid when it cannot flow out of the structure.\nSTRICT: only place the fluid once every non fluid element of the structure is satisfied.
-
-structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item=Forge fluid container item
-structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item.tooltip=Containers implementing Forge's IFluidContainerItem, e.g. most modded cells. They hold their fluid in their own NBT, so they are drained in place.
-structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry=Forge fluid container registry
-structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry.tooltip=Containers registered with Forge's FluidContainerRegistry, e.g. buckets. They are consumed as a whole, and are replaced by their empty container.
-structurelib.config.registries.fluidcontainerextractors=Fluid container extraction
-structurelib.config.registries.fluidcontainerextractors.tooltip=Controls which ways of pulling fluid out of an item are enabled during survival autoplace
-
-structurelib.config.registries.fluidsourceproviders=Fluid sources
-structurelib.config.registries.fluidsourceproviders.tooltip=Controls which additional ways of getting fluid are used during survival autoplace, e.g. an ME network the player can reach with a wireless terminal. Whatever the player is carrying is always used after these.

--- a/src/main/resources/assets/structurelib/lang/en_US.lang
+++ b/src/main/resources/assets/structurelib/lang/en_US.lang
@@ -202,14 +202,14 @@ structurelib.configgui.enabled=Enabled Entry
 structurelib.configgui.disabled=Disabled Entry
 structurelib.configgui.drag.tooltip=Drag this button to reorder this element.
 
-structurelib.sortedregistry.inventoryproviders.5000-main-inventory=Main Player Inventory
+structurelib.sortedregistry.inventoryproviders.5000-main-inventory=5000 Main Player Inventory
 structurelib.sortedregistry.inventoryproviders.5000-main-inventory.tooltip=36 slots of item in your main inventory. Armor slots excluded.
-structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=Ender Chest Inventory
+structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=7000 Ender Chest Inventory
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory.tooltip=Links to your vanilla ender chest inventory. Require at least one "ender backpack like" item in main inventory to work.
 
-structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item=Forge fluid container item
+structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item=3000 Forge fluid container item
 structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item.tooltip=Containers implementing Forge's IFluidContainerItem, e.g. most modded cells. They hold their fluid in their own NBT, so they are drained in place.
-structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry=Forge fluid container registry
+structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry=5000 Forge fluid container registry
 structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry.tooltip=Containers registered with Forge's FluidContainerRegistry, e.g. buckets. They are consumed as a whole, and are replaced by their empty container.
 
 structurelib.config.common.autoplace.tooltip=Configurations that control how survival autoplace places blocks.

--- a/src/main/resources/assets/structurelib/lang/zh_CN.lang
+++ b/src/main/resources/assets/structurelib/lang/zh_CN.lang
@@ -51,6 +51,7 @@ structurelib.autoplace.error.not_enabled=§c这个多方块结构不支持在生
 structurelib.autoplace.error.no_simple_block=§c建议放置 §r%s§c ，但没有找到它
 structurelib.autoplace.error.no_item_stack=§c建议使用 §r%s§c 放置方块，但没有找到它
 structurelib.autoplace.warning.no_explicit_channel=§6这个结构依赖于不存在的子信道 §r%s§6 。已使用主信道值替代。
+structurelib.autoplace.missing_block=§c缺少方块：%s
 structurelib.autoplace.missing_fluid=§c缺少流体：%s（%s）
 structurelib.autoplace.requirement_fluid=%s（%s）
 

--- a/src/main/resources/assets/structurelib/lang/zh_CN.lang
+++ b/src/main/resources/assets/structurelib/lang/zh_CN.lang
@@ -51,6 +51,8 @@ structurelib.autoplace.error.not_enabled=§c这个多方块结构不支持在生
 structurelib.autoplace.error.no_simple_block=§c建议放置 §r%s§c ，但没有找到它
 structurelib.autoplace.error.no_item_stack=§c建议使用 §r%s§c 放置方块，但没有找到它
 structurelib.autoplace.warning.no_explicit_channel=§6这个结构依赖于不存在的子信道 §r%s§6 。已使用主信道值替代。
+structurelib.autoplace.missing_fluid=§c缺少流体：%s（%s）
+structurelib.autoplace.requirement_fluid=%s（%s）
 
 structurelib.blockhint.desc.0=帮助你搭建机器
 structurelib.blockhint.0.name=提示方块：1号
@@ -189,6 +191,11 @@ structurelib.config.registries.stackextractors.tooltip=该注册表控制在生�
 structurelib.config.registries.inventoryproviders=物品栏定位
 structurelib.config.registries.inventoryproviders.tooltip=该注册表控制在生存模式自动放置时，可用的物品栏来源。
 
+structurelib.config.registries.fluidstackextractors=流体提取器
+structurelib.config.registries.fluidstackextractors.tooltip=该注册表控制在生存模式自动放置时，如何从物品（如林业背包）提取流体库存。
+structurelib.config.registries.fluidsourceproviders=流体栏定位
+structurelib.config.registries.fluidsourceproviders.tooltip=该注册表控制在生存模式自动放置时，可用的流体来源。
+
 structurelib.configgui.enabled=已启用
 structurelib.configgui.disabled=已禁用
 structurelib.configgui.drag.tooltip=拖动该按钮以重排。
@@ -198,19 +205,11 @@ structurelib.sortedregistry.inventoryproviders.5000-main-inventory.tooltip=不�
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=末影箱
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory.tooltip=当前玩家的末影箱。需要在主物品栏中存在类似于末影背包的东西才会实际生效。
 
-structurelib.autoplace.missing_fluid=§c缺少流体：%s（%s）
-structurelib.fluid.requirement=%s（%s mB）
+structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item=Forge 流体容器物品
+structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item.tooltip=实现 Forge 的 IFluidContainerItem 的容器，例如大多数模组流体容器。流体存于其 NBT 中，因此直接在原位抽取。
+structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry=Forge 流体容器注册表
+structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry.tooltip=注册到 Forge 的 FluidContainerRegistry 的容器，例如桶。整体消耗，并替换为其空容器。
 
 structurelib.config.common.autoplace.tooltip=控制生存模式自动放置如何放置方块的配置项。
 structurelib.config.common.autoplace.fluidAutoplace.tooltip=是否允许生存模式自动放置流体方块（例如多方块结构内部所需的水），从玩家的流体容器中抽取流体来支付。\n多方块结构也可以自行提供流体来源。\n此选项只关闭流体方块。多方块结构依旧可用，只是这些位置无法被自动放置填满。
 structurelib.config.common.autoplace.fluidGateMode.tooltip=在结构尚未完成时，自动放置放置流体的小心程度（否则流体会从结构中流出）。\nNONE：立即放置。\nLENIENT：只有当流体无法流出结构时才放置。\nSTRICT：只有当结构中所有非流体元件都满足后才放置流体。
-
-structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item=Forge 流体容器物品
-structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item.tooltip=实现 Forge 的 IFluidContainerItem 的容器，例如大多数模组流体容器。流体存于其 NBT 中，因此直接在原位抽取。
-structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry=Forge 流体容器注册表
-structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry.tooltip=注册到 Forge 的 FluidContainerRegistry 的容器，例如桶。整体消耗，并替换为其空容器。
-structurelib.config.registries.fluidcontainerextractors=流体容器提取
-structurelib.config.registries.fluidcontainerextractors.tooltip=该注册表控制在生存模式自动放置时，可从物品中抽取流体的方式。
-
-structurelib.config.registries.fluidsourceproviders=流体来源
-structurelib.config.registries.fluidsourceproviders.tooltip=该注册表控制在生存模式自动放置时，额外从哪些途径获取流体（例如玩家可用无线终端接入的 ME 网络）。玩家随身携带的流体始终在这些之后使用。

--- a/src/main/resources/assets/structurelib/lang/zh_CN.lang
+++ b/src/main/resources/assets/structurelib/lang/zh_CN.lang
@@ -197,3 +197,23 @@ structurelib.sortedregistry.inventoryproviders.5000-main-inventory=玩家物品�
 structurelib.sortedregistry.inventoryproviders.5000-main-inventory.tooltip=不包括护甲栏以外的36格。
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=末影箱
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory.tooltip=当前玩家的末影箱。需要在主物品栏中存在类似于末影背包的东西才会实际生效。
+
+structurelib.autoplace.missing_fluid=§c缺少流体：%s（%s）
+structurelib.fluid.requirement=%s（%s mB）
+
+structurelib.config.common.autoplace.tooltip=控制生存模式自动放置如何放置方块的配置项。
+structurelib.config.common.autoplace.fluidAutoplace.tooltip=是否允许生存模式自动放置流体方块（例如多方块结构内部所需的水），从玩家的流体容器中抽取流体来支付。\n多方块结构也可以自行提供流体来源。\n此选项只关闭流体方块。多方块结构依旧可用，只是这些位置无法被自动放置填满。
+structurelib.config.common.autoplace.fluidGateMode.tooltip=在结构尚未完成时，自动放置放置流体的小心程度（否则流体会从结构中流出）。\nNONE：立即放置。\nLENIENT：只有当流体无法流出结构时才放置。\nSTRICT：只有当结构中所有非流体元件都满足后才放置流体。
+
+structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item=Forge 流体容器物品
+structurelib.sortedregistry.fluidcontainerextractors.3000-forge-fluid-container-item.tooltip=实现 Forge 的 IFluidContainerItem 的容器，例如大多数模组流体容器。流体存于其 NBT 中，因此直接在原位抽取。
+structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry=Forge 流体容器注册表
+structurelib.sortedregistry.fluidcontainerextractors.5000-forge-fluid-container-registry.tooltip=注册到 Forge 的 FluidContainerRegistry 的容器，例如桶。整体消耗，并替换为其空容器。
+structurelib.config.registries.fluidcontainerextractors=流体容器提取
+structurelib.config.registries.fluidcontainerextractors.tooltip=该注册表控制在生存模式自动放置时，可从物品中抽取流体的方式。
+
+structurelib.config.registries.fluidsourceproviders=流体来源
+structurelib.config.registries.fluidsourceproviders.tooltip=该注册表控制在生存模式自动放置时，额外从哪些途径获取流体（例如玩家可用无线终端接入的 ME 网络）。玩家随身携带的流体始终在这些之后使用。
+
+structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc=ME 网络（无线终端）
+structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc.tooltip=当玩家携带的无线终端已链接且在无线接入点范围内时，直接从该 ME 网络抽取多方块结构所需的流体。

--- a/src/main/resources/assets/structurelib/lang/zh_CN.lang
+++ b/src/main/resources/assets/structurelib/lang/zh_CN.lang
@@ -214,6 +214,3 @@ structurelib.config.registries.fluidcontainerextractors.tooltip=该注册表控�
 
 structurelib.config.registries.fluidsourceproviders=流体来源
 structurelib.config.registries.fluidsourceproviders.tooltip=该注册表控制在生存模式自动放置时，额外从哪些途径获取流体（例如玩家可用无线终端接入的 ME 网络）。玩家随身携带的流体始终在这些之后使用。
-
-structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc=ME 网络（无线终端）
-structurelib.sortedregistry.fluidsourceproviders.0999-ae2fc.tooltip=当玩家携带的无线终端已链接且在无线接入点范围内时，直接从该 ME 网络抽取多方块结构所需的流体。

--- a/src/main/resources/assets/structurelib/lang/zh_CN.lang
+++ b/src/main/resources/assets/structurelib/lang/zh_CN.lang
@@ -200,14 +200,14 @@ structurelib.configgui.enabled=已启用
 structurelib.configgui.disabled=已禁用
 structurelib.configgui.drag.tooltip=拖动该按钮以重排。
 
-structurelib.sortedregistry.inventoryproviders.5000-main-inventory=玩家物品栏
+structurelib.sortedregistry.inventoryproviders.5000-main-inventory=5000 玩家物品栏
 structurelib.sortedregistry.inventoryproviders.5000-main-inventory.tooltip=不包括护甲栏以外的36格。
-structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=末影箱
+structurelib.sortedregistry.inventoryproviders.7000-ender-inventory=7000 末影箱
 structurelib.sortedregistry.inventoryproviders.7000-ender-inventory.tooltip=当前玩家的末影箱。需要在主物品栏中存在类似于末影背包的东西才会实际生效。
 
-structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item=Forge 流体容器物品
+structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item=3000 Forge 流体容器物品
 structurelib.sortedregistry.fluidstackextractors.3000-forge-fluid-container-item.tooltip=实现 Forge 的 IFluidContainerItem 的容器，例如大多数模组流体容器。流体存于其 NBT 中，因此直接在原位抽取。
-structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry=Forge 流体容器注册表
+structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry=5000 Forge 流体容器注册表
 structurelib.sortedregistry.fluidstackextractors.5000-forge-fluid-container-registry.tooltip=注册到 Forge 的 FluidContainerRegistry 的容器，例如桶。整体消耗，并替换为其空容器。
 
 structurelib.config.common.autoplace.tooltip=控制生存模式自动放置如何放置方块的配置项。


### PR DESCRIPTION
## Summary
Add fluid autoplace support for projectors

- Add `FluidPlacementRegistry` for fluid costs and custom placement logic, with water and lava registered by default
- Add fluid elements via `ofFluidBlock` / `ofFluid`; existing block-based structure definitions automatically become fluid elements when no item form exists
- Add overflow protection so fluids are placed only after the structure can contain them
- Charge only the missing fluid amount and restore the previous block if placement fails
- Support fluid sources from player containers, registered `FluidSourceProviders`, and multiblock build environments
- Add configuration for enabling fluid autoplace and gate strictness, including registry ordering/disabling
- Maintain API compatibility with default methods and no removed or changed public signatures

## Showcase

https://github.com/user-attachments/assets/d3a3f039-6d6b-46f0-a8e0-e9b533a8f352

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
